### PR TITLE
New server-to-server messaging feature

### DIFF
--- a/assets/js/paywalled-content.js
+++ b/assets/js/paywalled-content.js
@@ -61,7 +61,8 @@ jQuery(document).ready(function($) {
             hoverText: configData.hoverText,
             successText: configData.successText,
             onSuccess: configData.onSuccess,
-            theme: configData.theme
+            theme: configData.theme,
+            opReturn: configData.opReturn //This is a hack to give the PB server the post ID to send it back to WP's DB
         });
     });
 });

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -149,6 +149,8 @@ class PayButton_Admin {
             'logout_button_text_color'  => get_option( 'paybutton_logout_button_text_color', '#FFFFFF' ),
             // Blocklist
             'blocklist'                 => get_option( 'paybutton_blocklist', array() ),
+            //Public key
+            'paybutton_public_key'      => get_option( 'paybutton_public_key', '' ),
         );
         $this->load_admin_template( 'paywall-settings', $args );
     }
@@ -194,6 +196,11 @@ class PayButton_Admin {
             $blocklist = array_map( 'trim', explode( ',', $raw_blocklist ) );
             update_option( 'paybutton_blocklist', $blocklist );
         }
+        //Adding the new public key option
+        if ( isset( $_POST['paybutton_public_key'] ) ) {
+            $public_key = sanitize_text_field( $_POST['paybutton_public_key'] );
+            update_option( 'paybutton_public_key', $public_key );
+        }    
     }
 
     /**

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -171,6 +171,7 @@ class PayButton_Public {
                     'tertiary'  => $color_tertiary,
                 ),
             ),
+            'opReturn'    => (string) $post_id //This is a hack to give the PB server the post ID to send it back to WP's DB
         );
         ob_start(); //When ob_start() is called, PHP begins buffering all subsequent output instead of printing it to the browser.
         ?>

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -55,6 +55,15 @@
                     </label>
                 </td>
             </tr>
+            <!--NEW Public Key input field-->
+            <tr>
+                <th scope="row"><label for="paybutton_public_key">PayButton Public Key</label></th>
+                <td>
+                    <input type="text" name="paybutton_public_key" id="paybutton_public_key" class="regular-text" 
+                        value="<?php echo esc_attr( get_option('paybutton_public_key', '') ); ?>">
+                    <p class="description">Enter your PayButton public key to verify Payment Trigger requests.</p>
+                </td>
+            </tr>
             <!-- Sticky Header Settings -->
             <tr>
                 <th colspan="2"><h2>Sticky Header Settings</h2></th>


### PR DESCRIPTION
This new Payment Trigger feature will ensure users' payments are correctly recorded to the WP database upon successful payment, no matter what happens on the client side. Fixing: [#4](https://github.com/PayButton/wordpress-plugin/issues/4), this new feature is optional.

**To test:**

- Install the plugin
- Go to Paywall Settings and add your public key (copy from PayButton's dashboard)
- Go to PB's dashboard -> Button --> 'When a payment is received...' and add the following URL and config data:

**URL:** https://yoursite.com/wp-admin/admin-ajax.php?action=payment_trigger

**Config Data:**
```
{
"signature": <signature>,
"post_id": <opReturn>,
"tx_hash": <txId>,
"tx_amount": <amount>,
"tx_timestamp": <timestamp>,
"user_address": <inputAddresses>
}
```
- Now open your test site, unlock a post and close the PayButton dialog quickly (before its onSuccess is triggered)
- Now login using the sticky header and you will see your unlocked content from the Profile page