### PR TITLE
New scroll to unlocked content feature

### DIFF
--- a/assets/css/paywall-styles.css
+++ b/assets/css/paywall-styles.css
@@ -1,0 +1,16 @@
+.unlocked-indicator {
+    margin: 20px 0;
+    text-align: center;
+}
+.unlocked-indicator hr {
+    border: none;
+    border-top: 1px solid #ccc;
+    margin: 10px auto;
+    width: 80%;
+}
+.unlocked-indicator p {
+    margin: 5px 0;
+    font-weight: bold;
+    font-size: 0.80em;
+    color: #555;
+}

--- a/assets/js/paywalled-content.js
+++ b/assets/js/paywalled-content.js
@@ -48,6 +48,11 @@ jQuery(document).ready(function($) {
                 },
                 success: function() {
                     setTimeout(function() {
+                        // Build the new URL with the hash
+                        var newUrl = location.href.split('#')[0] + '#unlocked';
+                        // Replace the current URL in the address bar without triggering a navigation
+                        window.history.replaceState(null, '', newUrl);
+                        // Force a reload
                         location.reload();
                     }, 2000);
                 }
@@ -65,4 +70,23 @@ jQuery(document).ready(function($) {
             opReturn: configData.opReturn //This is a hack to give the PB server the post ID to send it back to WP's DB
         });
     });
+});
+
+//Scrolling to the unlocked content indicator element when the page loads
+jQuery(document).ready(function($) {
+    // Check if the URL hash is '#unlocked'
+    if (window.location.hash === '#unlocked') {
+        // Find the unlocked indicator element
+        var $target = $('#unlocked');
+        if ($target.length) {
+            // Calculate the scroll offset to the sticky header's height.
+            var headerOffset = 80;
+            var targetOffset = $target.offset().top - headerOffset;
+            
+            // Animate scrolling to the calculated offset so that the unlocked content indicator is visible.
+            $('html, body').animate({
+                scrollTop: targetOffset
+            }, 500);
+        }
+    }
 });

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -189,6 +189,8 @@ class PayButton_Admin {
         update_option( 'paybutton_profile_button_text_color', sanitize_hex_color( $_POST['profile_button_text_color'] ) ?: '#000' );
         update_option( 'paybutton_logout_button_bg_color', sanitize_hex_color( $_POST['logout_button_bg_color'] ) ?: '#d9534f' );
         update_option( 'paybutton_logout_button_text_color', sanitize_hex_color( $_POST['logout_button_text_color'] ) ?: '#FFFFFF' );
+        // New unlocked content indicator option:
+        update_option( 'paybutton_scroll_to_unlocked', isset( $_POST['paybutton_scroll_to_unlocked'] ) ? '1' : '0' );
 
         // Save the blocklist
         if ( isset( $_POST['paybutton_blocklist'] ) ) {

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -37,6 +37,10 @@ class PayButton_Public {
      */
     public function enqueue_public_assets() {
         wp_enqueue_style( 'paybutton-sticky-header', PAYBUTTON_PLUGIN_URL . 'assets/css/sticky-header.css', array(), '1.0' );
+
+        // Enqueue your new paywall styles
+        wp_enqueue_style( 'paywall-styles', PAYBUTTON_PLUGIN_URL . 'assets/css/paywall-styles.css', array(), '1.0' );
+
         // Add inline CSS variables.
         $custom_css = "
             :root {
@@ -94,6 +98,8 @@ class PayButton_Public {
             'isUserLoggedIn' => ! empty( $_SESSION['cashtab_ecash_address'] ) ? 1 : 0,
             'userAddress'    => ! empty( $_SESSION['cashtab_ecash_address'] ) ? $_SESSION['cashtab_ecash_address'] : '',
             'defaultAddress' => get_option( 'paybutton_paywall_ecash_address', '' ),
+            //Localize the Unlocked Content Indicator variable
+            'scrollToUnlocked' => get_option( 'paybutton_scroll_to_unlocked', '1' ),
         ) );
     }
 
@@ -152,8 +158,17 @@ class PayButton_Public {
         ), $atts );
 
         $post_id = get_the_ID();
+        //Modified the unlocked content logic to add the unlock indicator when the content is unlocked
         if ( $this->post_is_unlocked( $post_id ) ) {
-            return do_shortcode( $content );
+            $indicator = '';
+            if ( get_option('paybutton_scroll_to_unlocked', '0') === '1' ) {
+                $indicator = '<div id="unlocked" class="unlocked-indicator">
+                                  <hr>
+                                  <p>Unlocked Content Below</p>
+                                  <hr>
+                              </div>';
+            }
+            return $indicator . do_shortcode( $content );
         }
         // Prepare configuration data for the PayButton.
         $config = array(

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -55,6 +55,16 @@
                     </label>
                 </td>
             </tr>
+            <!--NEW Unlocked Content Indicator Checkbox-->
+            <tr>
+                <th scope="row">Unlocked Content Indicator</th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="paybutton_scroll_to_unlocked" value="1" <?php checked( get_option('paybutton_scroll_to_unlocked', '1'), '1' ); ?>>
+                        <span>After payment, show the unlocked content indicator and scroll to it</span>
+                    </label>
+                </td>
+            </tr>
             <!--NEW Public Key input field-->
             <tr>
                 <th scope="row"><label for="paybutton_public_key">PayButton Public Key</label></th>


### PR DESCRIPTION
This PR introduces a new feature that automatically scrolls users to the unlocked content section after a successful payment, enhancing the UX. The feature is enabled by default and can be toggled by a new checkbox in the Paywall Settings.