### PR TITLE
Added guide for admins to setup the new Payment Trigger feature.

### DIFF
--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -147,8 +147,8 @@ class PayButton_Admin {
             'profile_button_text_color' => get_option( 'paybutton_profile_button_text_color', '#000000' ),
             'logout_button_bg_color'    => get_option( 'paybutton_logout_button_bg_color', '#d9534f' ),
             'logout_button_text_color'  => get_option( 'paybutton_logout_button_text_color', '#FFFFFF' ),
-            // Blocklist
-            'blocklist'                 => get_option( 'paybutton_blocklist', array() ),
+            // blacklist
+            'blacklist'                 => get_option( 'paybutton_blacklist', array() ),
             //Public key
             'paybutton_public_key'      => get_option( 'paybutton_public_key', '' ),
         );
@@ -192,11 +192,11 @@ class PayButton_Admin {
         // New unlocked content indicator option:
         update_option( 'paybutton_scroll_to_unlocked', isset( $_POST['paybutton_scroll_to_unlocked'] ) ? '1' : '0' );
 
-        // Save the blocklist
-        if ( isset( $_POST['paybutton_blocklist'] ) ) {
-            $raw_blocklist = sanitize_text_field( $_POST['paybutton_blocklist'] );
-            $blocklist = array_map( 'trim', explode( ',', $raw_blocklist ) );
-            update_option( 'paybutton_blocklist', $blocklist );
+        // Save the blacklist
+        if ( isset( $_POST['paybutton_blacklist'] ) ) {
+            $raw_blacklist = sanitize_text_field( $_POST['paybutton_blacklist'] );
+            $blacklist = array_map( 'trim', explode( ',', $raw_blacklist ) );
+            update_option( 'paybutton_blacklist', $blacklist );
         }
         //Adding the new public key option
         if ( isset( $_POST['paybutton_public_key'] ) ) {

--- a/includes/class-paybutton-ajax.php
+++ b/includes/class-paybutton-ajax.php
@@ -154,13 +154,13 @@ class PayButton_AJAX {
         }
         $address = sanitize_text_field( $_POST['address'] );
 
-        // Retrieve the blocklist and check the address
-        $blocklist = get_option( 'paybutton_blocklist', array() );
-        if ( in_array( $address, $blocklist ) ) {
+        // Retrieve the blacklist and check the address
+        $blacklist = get_option( 'paybutton_blacklist', array() );
+        if ( in_array( $address, $blacklist ) ) {
             wp_send_json_error( array( 'message' => 'This eCash address is blocked.' ) );
             return;
         }
-        // Blocklist End
+        // blacklist End
 
         $_SESSION['cashtab_ecash_address'] = $address;
         setcookie(
@@ -244,9 +244,9 @@ class PayButton_AJAX {
 
             // If we have any address to store, insert a record
             if ( ! empty( $address_to_store ) ) {
-                // Check blocklist again in case user isn't logged in
-                $blocklist = get_option( 'paybutton_blocklist', array() );
-                if ( in_array( $address_to_store, $blocklist ) ) {
+                // Check blacklist again in case user isn't logged in
+                $blacklist = get_option( 'paybutton_blacklist', array() );
+                if ( in_array( $address_to_store, $blacklist ) ) {
                     wp_send_json_error( array( 'message' => 'This eCash address is blocked.' ) );
                     return;
                 }

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -65,15 +65,6 @@
                     </label>
                 </td>
             </tr>
-            <!--NEW Public Key input field-->
-            <tr>
-                <th scope="row"><label for="paybutton_public_key">PayButton Public Key</label></th>
-                <td>
-                    <input type="text" name="paybutton_public_key" id="paybutton_public_key" class="regular-text" 
-                        value="<?php echo esc_attr( get_option('paybutton_public_key', '') ); ?>">
-                    <p class="description">Enter your PayButton public key to verify Payment Trigger requests.</p>
-                </td>
-            </tr>
             <!-- Sticky Header Settings -->
             <tr>
                 <th colspan="2"><h2>Sticky Header Settings</h2></th>
@@ -120,10 +111,13 @@
                     <button type="button" onclick="document.getElementById('logout_button_text_color').value = '#fff';">Reset</button>
                 </td>
             </tr>
-
+            <!--NEW Advanced Settings tab-->
+            <tr>
+                <th colspan="2"><h2>Advanced Settings</h2></th>
+            </tr>
             <!--Blocklist Field -->
             <tr>
-                <th scope="row"><label for="paybutton_blocklist">Blocklisted eCash Addresses</label></th>
+                <th scope="row"><label for="paybutton_blocklist">Blocklisted eCash Addresses (optional)</label></th>
                 <td>
                     <textarea name="paybutton_blocklist" id="paybutton_blocklist" rows="4" cols="50"><?php
                         // Convert the blocklist array into a comma-separated string for display
@@ -132,7 +126,56 @@
                     <p class="description">Enter comma-separated eCash addresses to block from logging in via Cashtab.</p>
                 </td>
             </tr>
-
+            <!--NEW Public Key input field-->
+            <tr>
+                <th scope="row">
+                    <label for="paybutton_public_key">PayButton Public Key (optional)</label>
+                </th>
+                <td>
+                    <input type="text" name="paybutton_public_key" id="paybutton_public_key" class="regular-text" value="<?php echo esc_attr( get_option('paybutton_public_key', '') ); ?>">
+                    <p class="description">
+                        Enter your PayButton public key to verify Payment Trigger requests.
+                    </p>
+                    <!-- User-Friendly Setup Guide -->
+                    <div class="paybutton-guide" style="margin-top: 15px; background: #f7f7f7; padding: 15px; border-left: 4px solid #0073aa;">
+                        <p><strong>Guide to Setup your PayButton Public Key:</strong></p>
+                        <p>
+                            1. Create an account on 
+                            <a href="https://paybutton.org/signup" target="_blank" rel="noopener noreferrer">PayButton.org</a> 
+                            and copy your public key from the <a href="https://paybutton.org/account" target="_blank" rel="noopener noreferrer">account page</a> and past it in the Public Key field above.
+                        </p>
+                        <p>
+                            2. <a href="https://paybutton.org/button" target="_blank" rel="noopener noreferrer">Create a button</a> 
+                            for your paywall receiving eCash address.
+                        </p>
+                        <p>
+                            3. Scroll down on the button page to the section <em>"When a Payment is Received..."</em>.
+                        </p>
+                        <p>
+                            4. In the URL field, paste the following, replacing <em>yoursite.com</em> with your website URL:
+                        </p>
+                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;">https://yoursite.com/wp-admin/admin-ajax.php?action=payment_trigger</pre>
+                        <p>
+                            5. In the <em>Post Data</em> field, paste the following code as is:
+                        </p>
+                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;">
+{
+"signature": &lt;signature&gt;,
+"post_id": &lt;opReturn&gt;,
+"tx_hash": &lt;txId&gt;,
+"tx_amount": &lt;amount&gt;,
+"tx_timestamp": &lt;timestamp&gt;,
+"user_address": &lt;inputAddresses&gt;
+}</pre>
+                            <p>
+                                6. Save your button settings after pasting these values, and you're all set!
+                            </p>
+                            <p>
+                                <strong>Note:</strong> Enabling this feature is strongly recommended as it improves reliability. Payment Trigger feature leverages secure, server-to-server messaging to record paywall transactions in your database.
+                            </p>
+                    </div>
+                </td>
+            </tr>
         </table>
         <p class="submit">
             <button type="submit" name="paybutton_paywall_save_settings" class="button button-primary">Save Changes</button>

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -115,13 +115,13 @@
             <tr>
                 <th colspan="2"><h2>Advanced Settings</h2></th>
             </tr>
-            <!--Blocklist Field -->
+            <!--blacklist Field -->
             <tr>
-                <th scope="row"><label for="paybutton_blocklist">Blacklisted eCash Addresses (optional)</label></th>
+                <th scope="row"><label for="paybutton_blacklist">Blacklisted eCash Addresses (optional)</label></th>
                 <td>
-                    <textarea name="paybutton_blocklist" id="paybutton_blocklist" rows="4" cols="50"><?php
-                        // Convert the blocklist array into a comma-separated string for display
-                        echo esc_textarea( isset($blocklist) ? implode(', ', (array) $blocklist ) : '' );
+                    <textarea name="paybutton_blacklist" id="paybutton_blacklist" rows="4" cols="50"><?php
+                        // Convert the blacklist array into a comma-separated string for display
+                        echo esc_textarea( isset($blacklist) ? implode(', ', (array) $blacklist ) : '' );
                     ?></textarea>
                     <p class="description">Enter comma-separated eCash addresses to block from logging in via Cashtab.</p>
                 </td>

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -117,7 +117,7 @@
             </tr>
             <!--Blocklist Field -->
             <tr>
-                <th scope="row"><label for="paybutton_blocklist">Blocklisted eCash Addresses (optional)</label></th>
+                <th scope="row"><label for="paybutton_blocklist">Blacklisted eCash Addresses (optional)</label></th>
                 <td>
                     <textarea name="paybutton_blocklist" id="paybutton_blocklist" rows="4" cols="50"><?php
                         // Convert the blocklist array into a comma-separated string for display
@@ -145,16 +145,16 @@
                             and copy your public key from the <a href="https://paybutton.org/account" target="_blank" rel="noopener noreferrer">account page</a> and past it in the Public Key field above.
                         </p>
                         <p>
-                            2. <a href="https://paybutton.org/button" target="_blank" rel="noopener noreferrer">Create a button</a> 
+                            2. <a href="https://paybutton.org/buttons" target="_blank" rel="noopener noreferrer">Create a button</a> 
                             for your paywall receiving eCash address.
                         </p>
                         <p>
                             3. Scroll down on the button page to the section <em>"When a Payment is Received..."</em>.
                         </p>
                         <p>
-                            4. In the URL field, paste the following, replacing <em>yoursite.com</em> with your website URL:
+                            4. In the URL field, paste the following:
                         </p>
-                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;">https://yoursite.com/wp-admin/admin-ajax.php?action=payment_trigger</pre>
+                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;"><?php echo esc_url( home_url( '/wp-admin/admin-ajax.php?action=payment_trigger' ) ); ?></pre>
                         <p>
                             5. In the <em>Post Data</em> field, paste the following code as is:
                         </p>
@@ -171,7 +171,7 @@
                                 6. Save your button settings after pasting these values, and you're all set!
                             </p>
                             <p>
-                                <strong>Note:</strong> Enabling this feature is strongly recommended as it improves reliability. Payment Trigger feature leverages secure, server-to-server messaging to record paywall transactions in your database.
+                                <strong>Note:</strong> Enabling this feature is strongly recommended as it improves payment reliability, leveraging secure server-to-server messaging to record paywall transactions to your database.
                             </p>
                     </div>
                 </td>


### PR DESCRIPTION
Add admin guide for optional PayButton Public Key setup that improves transaction reliability via the new Payment Trigger feature (server-to-server messaging). Fixing [Issue #6](https://github.com/PayButton/wordpress-plugin/issues/6).

**Test:**
![image](https://github.com/user-attachments/assets/5af36d5d-f58a-49d1-8660-26a24622e055)