### PR TITLE
Fix session synchronization

### DIFF
--- a/paybutton.php
+++ b/paybutton.php
@@ -63,4 +63,4 @@ add_action( 'plugins_loaded', function() {
 
     // Initialize AJAX handlers.
     new PayButton_AJAX();
-} );
+}, 1);  // Use a priority to ensure this runs before other actions that might depend on session data.


### PR DESCRIPTION
This fix uses a priority to ensure the session starts before other actions that might depend on session data.

**Test plan:**

- Upload this updated plugin to your test site
- Visit the site
- Open Dev Console --> Application --> Cookies
- Make sure you see "PHPSESSID" in the cookies storage consistently