### PR TITLE
Changed the generic names of the functions

### DIFF
--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -26,7 +26,7 @@ class PayButton_Public {
     public function __construct() {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_public_assets' ) );
         add_action( 'wp_body_open', array( $this, 'output_sticky_header' ) );
-        add_shortcode( 'paywalled_content', array( $this, 'paywalled_content_shortcode' ) );
+        add_shortcode( 'paywalled_content', array( $this, 'paybutton_paywall_shortcode' ) );
         add_shortcode( 'paybutton_profile', array( $this, 'profile_shortcode' ) );
         add_filter( 'comments_open', array( $this, 'filter_comments_open' ), 999, 2 );
         add_action( 'pre_get_comments', array( $this, 'filter_comments_query' ), 999 );
@@ -137,7 +137,7 @@ class PayButton_Public {
      * Outputs a `div` with encoded PayButton config for front-end handling.
     */
 
-    public function paywalled_content_shortcode( $atts, $content = null ) {
+    public function paybutton_paywall_shortcode( $atts, $content = null ) {
         if ( ! is_singular() || ! in_the_loop() ) {
             return '';
         }

--- a/templates/admin/content.php
+++ b/templates/admin/content.php
@@ -4,7 +4,7 @@
     <p><strong>Total Content Unlocks: </strong><?php echo esc_html( intval( $total_unlocks ) ); ?></p>
     <p><strong>Total Earned (XEC):</strong> <?php echo esc_html( number_format( $grand_total_earned, 2 ) ); ?></p>
     <?php
-    function sort_link_content( $col, $label, $orderby, $order, $base_url ) {
+    function paybutton_sort_content_table( $col, $label, $orderby, $order, $base_url ) {
         $arrow = '';
         $next_order = 'ASC';
         if ( $orderby === $col ) {
@@ -22,9 +22,9 @@
     <table class="widefat fixed striped">
         <thead>
             <tr>
-                <th><?php echo wp_kses_post( sort_link_content( 'title', 'Content Title', $orderby, $order, $base_url ) ); ?></th>
-                <th><?php echo wp_kses_post( sort_link_content( 'unlock_count', 'Unlocks', $orderby, $order, $base_url ) ); ?></th>
-                <th><?php echo wp_kses_post( sort_link_content( 'total_earned', 'Total Earned (XEC)', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_content_table( 'title', 'Content Title', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_content_table( 'unlock_count', 'Unlocks', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_content_table( 'total_earned', 'Total Earned (XEC)', $orderby, $order, $base_url ) ); ?></th>
             </tr>
         </thead>
         <tbody>

--- a/templates/admin/customers.php
+++ b/templates/admin/customers.php
@@ -61,7 +61,7 @@
         <p><strong>Total Customers:</strong> <?php echo intval( $total_customers ); ?></p>
         <p><strong>Total Earned (XEC):</strong> <?php echo number_format( $grand_total_xec, 2 ); ?> XEC</p>
         <?php
-        function sort_link( $col, $label, $orderby, $order, $base_url ) {
+        function paybutton_sort_customers_table( $col, $label, $orderby, $order, $base_url ) {
             $next_order = 'ASC';
             $arrow = '';
             if ( $orderby === $col ) {
@@ -79,10 +79,10 @@
         <table class="widefat fixed striped">
             <thead>
                 <tr>
-                <th><?php echo wp_kses_post( sort_link( 'ecash_address', 'Customer', $orderby, $order, $base_url ) ); ?></th>
-                <th><?php echo wp_kses_post( sort_link( 'unlocked_count', 'Unlocked Content', $orderby, $order, $base_url ) ); ?></th>
-                <th><?php echo wp_kses_post( sort_link( 'total_paid', 'Total Paid (XEC)', $orderby, $order, $base_url ) ); ?></th>
-                <th><?php echo wp_kses_post( sort_link( 'last_unlock_ts', 'Last Unlock', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_customers_table( 'ecash_address', 'Customer', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_customers_table( 'unlocked_count', 'Unlocked Content', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_customers_table( 'total_paid', 'Total Paid (XEC)', $orderby, $order, $base_url ) ); ?></th>
+                <th><?php echo wp_kses_post( paybutton_sort_customers_table( 'last_unlock_ts', 'Last Unlock', $orderby, $order, $base_url ) ); ?></th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
This PR fixes https://github.com/PayButton/wordpress-plugin/issues/17 by changing generic function names to more specific names with the paybutton prefix.

**To test:**
Install the plugin
Test the customers and Content page headers and confirm they work as before.