### PR TITLE
Fix hardcoded admin ajax endpoint

### DIFF
--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -158,7 +158,7 @@
                         <p>
                             4. In the <em>URL</em> field, paste the following:
                         </p>
-                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;"><?php echo esc_url( home_url( '/wp-admin/admin-ajax.php?action=payment_trigger' ) ); ?></pre>
+                        <pre style="background: #eaeaea; padding: 10px; border: 1px solid #ddd;"><?php echo esc_url( admin_url( 'admin-ajax.php?action=payment_trigger' ) ); ?></pre>
                         <p>
                             5. In the <em>Post Data</em> field, paste the following code as is:
                         </p>


### PR DESCRIPTION
This PR fixes: https://github.com/PayButton/wordpress-plugin/issues/30

Test plan:
Open PayButton Paywall settings and check if you can see the correct URL like: 
`https://test.com/wp-admin/admin-ajax.php?payment_trigger`