### PR TITLE
Implement Native PayButton Generator

### DIFF
--- a/assets/css/paybutton-admin.css
+++ b/assets/css/paybutton-admin.css
@@ -60,6 +60,118 @@
 }
 
 /* ------------------------------
+   Button Generator Page Styles
+------------------------------ */
+.pb-generator-container {
+    display: flex;
+    gap: 2rem;
+  }
+  
+.pb-generator-form {
+  flex: 1;
+  max-width: 400px;
+}
+
+.pb-generator-form label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.pb-generator-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.pb-generator-preview {
+  flex: 1;
+}
+
+#pbGenPreview {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 80px;
+}
+
+#pbGenShortcode {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Grouped Colors */
+.pb-generator-colors {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.pb-generator-colors .pb-generator-color {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+} 
+
+.pb-generator-widget {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.pb-generator-widget input[type="checkbox"] {
+  margin-left: 0.7rem;
+}
+
+/* Simple custom tooltip styling */
+.pbTooltip {
+  position: absolute;
+  cursor: help;
+  margin-left: 0.3rem;
+}
+
+.pbTooltip::before {
+  padding: 5px 3px;
+}
+
+.pbTooltip::after {
+  content: '';
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  pointer-events: none;
+  z-index: 999999;         /* ensure it stays above WP admin menu */
+  max-width: 300px;        
+  background: #0074C2;
+  color: #fff;
+  padding: 5px 2px;
+  border-radius: 3px;
+  white-space: normal;
+  overflow-wrap: break-word;
+  text-align: center;
+}
+
+.pbTooltip:hover::after {
+  content: attr(data-tooltip);
+  opacity: 1;
+  padding: 5px 10px;
+}
+
+.shortcode-note {
+  font-size: 0.9em;
+  color: #555;
+  margin-top: 0.5rem;
+  font-style: italic;
+}
+/* ------------------------------
    Paywall Settings page styles
 ------------------------------ */
 #adminAddressValidationResult {

--- a/assets/css/paybutton-admin.css
+++ b/assets/css/paybutton-admin.css
@@ -89,19 +89,43 @@
   flex: 1;
 }
 
-#pbGenPreview {
-  border: 1px solid #ccc;
+.pb-generator-preview #pbGenPreview {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
   padding: 1rem;
-  text-align: center;
+  min-height: 80px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 80px;
+  font-size: 1rem;
+  color: #333;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.pb-generator-preview #pbGenPreview:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  border-color: #0074C2;
 }
 
 #pbGenShortcode {
+  font-family: monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: #333;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
   width: 100%;
-  box-sizing: border-box;
+  resize: vertical;
+  word-break: break-all;
+}
+
+#pbGenToValidationResult{
+  margin-top: 0px;
 }
 
 /* Grouped Colors */
@@ -197,4 +221,47 @@ table.widefat.fixed.striped td {
 ------------------------------ */
 .pb-paragraph-margin-top {
     margin-top: 1rem;
+}
+
+/* ------------------------------
+   Utility - Clipboard
+------------------------------ */
+.shortcode-container {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.shortcode-container textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* The overlay covers the textarea but is hidden by default */
+.copy-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(66, 123, 236, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: #f6f7f7;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Show the overlay when hovering over the container */
+.shortcode-container:hover .copy-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.copy-overlay .overlay-text {
+  text-align: center;
+  font-weight:bold;
 }

--- a/assets/js/addressValidator.bundle.js
+++ b/assets/js/addressValidator.bundle.js
@@ -749,7 +749,7 @@
 
     var cashaddrExports = requireCashaddr();
 
-    // src/addressValidator.js
+	window.cashaddrExports = cashaddrExports;
 
     document.addEventListener('DOMContentLoaded', () => {
       // Find the wallet address input field by its ID.
@@ -771,8 +771,8 @@
       addressInput.addEventListener('input', () => {
         const address = addressInput.value.trim();
         if (address === "") {
-          resultSpan.textContent = '❌ Invalid address';
-          resultSpan.style.color = 'red';
+          resultSpan.textContent = '';
+          resultSpan.style.color = '';
           if (saveButton) saveButton.disabled = true;
           return;
         }

--- a/assets/js/paybutton-generator.js
+++ b/assets/js/paybutton-generator.js
@@ -1,0 +1,118 @@
+/* File: assets/js/paybutton-generator.js
+*/
+(function($) {
+  "use strict";
+
+  /* ==========================================================================
+     BUTTON GENERATOR LOGIC
+     ========================================================================== */
+  if ($('#pbGenTo').length) {
+    function updateGenerator() {
+      // Define default values for required options
+      const defaults = {
+        to:"",
+        text: "🧋 Buy me a coffee",
+        currency: "XEC",
+        animation: "slide",
+        successText: "Thank You",
+        primary: "#0074C2",
+        secondary: "#ffffff",
+        tertiary: "#231F20"
+      };
+
+      const toVal         = $('#pbGenTo').val().trim() || defaults.to;
+      const amountVal     = $('#pbGenAmount').val().trim();
+      const currencyVal   = $('#pbGenCurrency').val().trim() || defaults.currency;
+      const textVal       = $('#pbGenText').val().trim() || defaults.text;
+      const hoverVal      = $('#pbGenHover').val().trim();
+      const successVal    = $('#pbGenSuccessText').val().trim() || defaults.successText;
+      const animationVal  = $('#pbGenAnimation').val().trim() || defaults.animation;
+      const goalVal       = $('#pbGenGoal').val().trim();
+      const primaryVal    = $('#pbGenPrimary').val().trim() || defaults.primary;
+      const secondaryVal  = $('#pbGenSecondary').val().trim() || defaults.secondary;
+      const tertiaryVal   = $('#pbGenTertiary').val().trim() || defaults.tertiary;
+      const widgetChecked = $('#pbGenWidget').is(':checked');
+
+      // Build PB's config object
+      let config = {};
+      if(toVal !== '') { config.to = toVal; }
+      if(amountVal !== '') { config.amount = parseFloat(amountVal); }
+      config.currency = currencyVal;
+      if(textVal !== '') { config.text = textVal; }
+      if(hoverVal !== '') { config.hoverText = hoverVal; }
+      config.successText = successVal;
+      config.animation = animationVal;
+      if(goalVal !== '') { config.goalAmount = parseFloat(goalVal); }
+      config.theme = {
+        palette: {
+          primary: primaryVal,
+          secondary: secondaryVal,
+          tertiary: tertiaryVal
+        }
+      };
+      config.widget = widgetChecked;
+    
+      // Get the preview container
+      const previewContainer = document.getElementById('pbGenPreview');
+      if (previewContainer) {
+        // Remove all child nodes
+        while (previewContainer.firstChild) {
+          previewContainer.removeChild(previewContainer.firstChild);
+        }
+        // Create a new inner container for rendering the button
+        const innerContainer = document.createElement('div');
+        previewContainer.appendChild(innerContainer);
+
+        // Render the button using the local paybutton.js
+        if (typeof PayButton !== 'undefined') {
+          if (widgetChecked) {
+            PayButton.renderWidget(innerContainer, config);
+          } else {
+            PayButton.render(innerContainer, config);
+          }
+        } else {
+          previewContainer.innerHTML = '<p>Error: paybutton.js not loaded.</p>';
+        }
+      }
+    
+      // Generate shortcode with config attribute
+      const shortcode = `[paybutton config='${JSON.stringify(config)}'][/paybutton]`;
+      $('#pbGenShortcode').val(shortcode);
+    }
+  
+    // Bind updates on input and change events
+    $('#pbGenTo, #pbGenAmount, #pbGenCurrency, #pbGenText, #pbGenAnimation, #pbGenGoal, #pbGenHover, #pbGenPrimary, #pbGenSecondary, #pbGenTertiary, #pbGenSuccessText, #pbGenWidget')
+      .on('input change', updateGenerator);
+  
+    // Initialize the generator on page load
+    updateGenerator();
+  }
+
+  /* ==========================================================================
+     SHORTCODE RENDERING LOGIC ON THE FRONT-END
+     ========================================================================== */
+  function renderPayButtonShortcodes() {
+    const containers = document.querySelectorAll('.paybutton-shortcode-container');
+    containers.forEach(container => {
+      const configStr = container.getAttribute('data-config');
+      try {
+        const config = JSON.parse(configStr);
+        if (typeof PayButton !== 'undefined') {
+          if (config.widget) {
+            PayButton.renderWidget(container, config);
+          } else {
+            PayButton.render(container, config);
+          }
+        } else {
+          container.innerHTML = '<p>Error: paybutton.js not loaded.</p>';
+        }
+      } catch (err) {
+        console.error('Invalid PayButton config JSON:', err);
+      }
+    });
+  }
+  
+  // Run shortcode rendering on DOMContentLoaded
+  document.addEventListener('DOMContentLoaded', renderPayButtonShortcodes);
+
+})(jQuery);

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -123,18 +123,27 @@ class PayButton_Admin {
         // Only load the generator JS on the PayButton Generator page
         if ( $hook_suffix === 'paybutton_page_paybutton-generator' ) {
 
+            // Enqueue the bundled address validator script
+            wp_enqueue_script(
+                'address-validator',
+                PAYBUTTON_PLUGIN_URL . 'assets/js/addressValidator.bundle.js',
+                array(),
+                '2.0.0',
+                true
+            );
+
             wp_enqueue_script(
                 'paybutton-core',
                 PAYBUTTON_PLUGIN_URL . 'assets/js/paybutton.js',
-                array(),
+                array('address-validator'),
                 '1.0',
-                false
+                true
             );
 
             wp_enqueue_script(
                 'paybutton-generator',
                 PAYBUTTON_PLUGIN_URL . 'assets/js/paybutton-generator.js',
-                array('jquery'),
+                array('jquery','paybutton-core','address-validator'),
                 '1.0',
                 true
             );

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -35,6 +35,15 @@ class PayButton_Admin {
 
         add_submenu_page(
             'paybutton',
+            'Button Generator',
+            'Button Generator',
+            'manage_options',
+            'paybutton-generator',
+            array( $this, 'button_generator_page' )
+        );
+
+        add_submenu_page(
+            'paybutton',
             'Paywall Settings',
             'Paywall Settings',
             'manage_options',
@@ -110,6 +119,26 @@ class PayButton_Admin {
                 true
             );
         }
+
+        // Only load the generator JS on the PayButton Generator page
+        if ( $hook_suffix === 'paybutton_page_paybutton-generator' ) {
+
+            wp_enqueue_script(
+                'paybutton-core',
+                PAYBUTTON_PLUGIN_URL . 'assets/js/paybutton.js',
+                array(),
+                '1.0',
+                false
+            );
+
+            wp_enqueue_script(
+                'paybutton-generator',
+                PAYBUTTON_PLUGIN_URL . 'assets/js/paybutton-generator.js',
+                array('jquery'),
+                '1.0',
+                true
+            );
+        }
     }
 
     /**
@@ -134,10 +163,17 @@ class PayButton_Admin {
      */
     public function dashboard_page() {
         $args = array(
-            'generate_button_url'  => 'https://paybutton.org/#button-generator',
+            'generate_button_url'  => esc_url( admin_url( 'admin.php?page=paybutton-generator' ) ),
             'paywall_settings_url' => esc_url( admin_url( 'admin.php?page=paybutton-paywall' ) )
         );
         $this->load_admin_template( 'dashboard', $args );
+    }
+
+    public function button_generator_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $this->load_admin_template( 'paybutton-generator' );
     }
 
     /**

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -11,13 +11,13 @@
     <div class="paybutton-dashboard-buttons">
         <!-- Button 1: Generate Button -->
         <div class="paybutton-dashboard-button">
-            <a href="https://paybutton.org/#button-generator" target="_blank" class="button button-primary paybutton-dashboard-link">
-                Add Simple PayButton
+            <a href="<?php echo $generate_button_url; ?>" class="button button-primary paybutton-dashboard-link">
+                PayButton Generator
             </a>
         </div>
         <!-- Button 2: Paywall Settings -->
         <div class="paybutton-dashboard-button">
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=paybutton-paywall' ) ); ?>" class="button button-primary paybutton-dashboard-link">
+            <a href="<?php echo $paywall_settings_url; ?>" class="button button-primary paybutton-dashboard-link">
                 Paywall Settings
             </a>
         </div>

--- a/templates/admin/paybutton-generator.php
+++ b/templates/admin/paybutton-generator.php
@@ -1,0 +1,134 @@
+<!-- File: templates/admin/paybutton-generator.php -->
+<?php
+    if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+    
+    //Get admin's wallet address from paywall settings
+    $admin_address = get_option( 'pb_paywall_admin_wallet_address', '' );
+?>
+
+<div class="wrap">
+  <h1>Button Generator</h1>
+  <h2>Build your custom PayButton and begin accepting payments!</h2>
+
+  <div class="pb-generator-container">
+    <div class="pb-generator-form">
+      <label for="pbGenTo">TO
+      <span class="pbTooltip" data-tooltip="Where the money will be sent to">?</span>
+      </label>
+      <input 
+        type="text" 
+        id="pbGenTo" 
+        placeholder="Your Wallet Address"
+        value="<?php echo esc_attr( $admin_address ); ?>"
+        class="pb-generator-input"
+      >
+
+      <label for="pbGenAmount">AMOUNT
+      <span class="pbTooltip" data-tooltip="How much money to request">?</span>
+      </label>
+      <input 
+        type="number" 
+        step="any" 
+        id="pbGenAmount" 
+        value="" 
+        class="pb-generator-input"
+        min="0"
+      >
+
+      <label for="pbGenCurrency">CURRENCY</label>
+      <select id="pbGenCurrency" class="pb-generator-input">
+        <option value="XEC" selected>XEC</option>
+        <option value="USD">USD</option>
+        <option value="CAD">CAD</option>
+      </select>
+
+      <label for="pbGenText">TEXT
+      <span class="pbTooltip" data-tooltip="The text displayed on the button">?</span>
+      </label>
+      <input 
+        type="text" 
+        id="pbGenText" 
+        placeholder="🧋 Buy me a coffee"
+        value=""
+        class="pb-generator-input"
+      >
+
+      <label for="pbGenHover">HOVER TEXT
+      <span class="pbTooltip" data-tooltip="The text displayed on the button on hover">?</span>
+      </label>
+      <input 
+        type="text" 
+        id="pbGenHover" 
+        placeholder="Send payment"
+        class="pb-generator-input"
+      >
+
+      <label for="pbGenSuccessText">SUCCESS TEXT
+      <span class="pbTooltip" data-tooltip="The text displayed upon successful payment">?</span>
+      </label>
+      <input 
+        type="text" 
+        id="pbGenSuccessText" 
+        placeholder="Thanks for your support" 
+        class="pb-generator-input"
+      >
+
+      <label for="pbGenAnimation">ANIMATION
+      <span class="pbTooltip" data-tooltip="The button hover animation">?</span>  
+      </label>
+      <select id="pbGenAnimation" class="pb-generator-input">
+        <option value="slide" selected>Slide</option>
+        <option value="invert">Invert</option>
+        <option value="none">None</option>
+      </select>
+
+      <label for="pbGenGoal">GOAL AMOUNT
+      <span class="pbTooltip" data-tooltip="Specifies a funding goal amount, indicated with a progress bar">?</span>
+      </label>
+      <input 
+        type="number" 
+        step="any" 
+        id="pbGenGoal" 
+        placeholder="Goal Amount" 
+        class="pb-generator-input"
+        min="0"
+      >
+
+      <label>Colors
+      <span class="pbTooltip" data-tooltip="The primary, secondary, and tertiary are color options that allow for custom themeing">?</span>  
+      </label>
+      <div class="pb-generator-colors">
+        <div class="pb-generator-color">
+          <label for="pbGenPrimary">PRIMARY</label>
+          <input type="color" id="pbGenPrimary" value="#0074C2">
+        </div>
+        <div class="pb-generator-color">
+          <label for="pbGenSecondary">SECONDARY</label>
+          <input type="color" id="pbGenSecondary" value="#ffffff">
+        </div>
+        <div class="pb-generator-color">
+          <label for="pbGenTertiary">TERTIARY</label>
+          <input type="color" id="pbGenTertiary" value="#231F20">
+        </div>
+      </div>
+
+      <div class="pb-generator-widget">
+        <label for="pbGenWidget">Widget
+        <span class="pbTooltip" data-tooltip="Creates an always-visible PayButton Widget">?</span>  
+        </label>
+        <input type="checkbox" id="pbGenWidget">
+      </div>
+
+    </div>
+
+    <div class="pb-generator-preview">
+      <h3>PREVIEW</h3>
+      <div id="pbGenPreview">
+        Enter an address
+      </div>
+      <h3>SHORTCODE</h3>
+      <p class="shortcode-note">Copy and paste the shortcode generated below wherever you want the PayButton to appear on your site.</p>
+      <textarea id="pbGenShortcode" rows="5" readonly></textarea>
+    </div>
+  </div>
+</div>

--- a/templates/admin/paybutton-generator.php
+++ b/templates/admin/paybutton-generator.php
@@ -18,7 +18,7 @@
       <input 
         type="text" 
         id="pbGenTo" 
-        placeholder="Your Wallet Address"
+        placeholder="Your Wallet Address (XEC or BCH)"
         value="<?php echo esc_attr( $admin_address ); ?>"
         class="pb-generator-input"
       >
@@ -38,6 +38,7 @@
       <label for="pbGenCurrency">CURRENCY</label>
       <select id="pbGenCurrency" class="pb-generator-input">
         <option value="XEC" selected>XEC</option>
+        <option value="BCH">BCH</option>
         <option value="USD">USD</option>
         <option value="CAD">CAD</option>
       </select>
@@ -127,8 +128,15 @@
         Enter an address
       </div>
       <h3>SHORTCODE</h3>
-      <p class="shortcode-note">Copy and paste the shortcode generated below wherever you want the PayButton to appear on your site.</p>
-      <textarea id="pbGenShortcode" rows="5" readonly></textarea>
+      <p class="shortcode-note">
+      Click the shortcode below to copy it, then paste it anywhere you'd like the PayButton to appear on your site.
+      </p>
+      <div class="shortcode-container">
+        <textarea id="pbGenShortcode" rows="5" readonly></textarea>
+        <div class="copy-overlay" data-target="#pbGenShortcode">
+          <span class="overlay-text">Click to copy!</span>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR implements issue #1 by adding native support for a PayButton generator. The new generator is a streamlined version of the [Button Generator](https://paybutton.org/#button-generator) found on PayButton.org. With this enhancement, WordPress administrators can easily create simple buttons (for donations, "buy me a coffee", etc.) and embed them into posts or pages using a shortcode.

Test plan:

- Install the plugin
- Go to the Button Generator page (either from the menu or from the PayButton Dashboard)
- If the styling of the Button Generator page seems off, then clear the cache by hard-refreshing the page (WP caches CSS for admin pages)
- Generate a button
- Check the form's functionalities (Tooltips, dropdowns...)
- Copy-paste the generated shortcode to a post or page and verify that it works