### PR TITLE
Added nonce and user permission check

### DIFF
--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -71,14 +71,18 @@ class PayButton_Admin {
     }
 
     public function handle_save_settings() {
-        if ( isset( $_POST['paybutton_paywall_save_settings'] ) && current_user_can( 'manage_options' ) ) {
+        if (
+            isset( $_POST['paybutton_paywall_save_settings'] ) &&
+            isset( $_POST['paybutton_settings_nonce'] ) &&
+            wp_verify_nonce( $_POST['paybutton_settings_nonce'], 'paybutton_paywall_settings' ) &&
+            current_user_can( 'manage_options' )
+        ) {
             $this->save_settings();
-            // Flush the cache for the wallet address option
-            wp_cache_delete('pb_paywall_admin_wallet_address', 'options');
+            wp_cache_delete( 'pb_paywall_admin_wallet_address', 'options' );
             wp_redirect( admin_url( 'admin.php?page=paybutton-paywall&settings-updated=true' ) );
             exit;
         }
-    }    
+    }      
 
     /**
      * This function is hooked into the admin_enqueue_scripts action. It receives a
@@ -294,6 +298,13 @@ class PayButton_Admin {
      * Output the Customers page.
      */
     public function customers_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( isset( $_GET['paybutton_customers_nonce'] ) &&
+             ! wp_verify_nonce( $_GET['paybutton_customers_nonce'], 'paybutton_customers_sort' ) ) {
+            wp_die( 'Security check failed' );
+        }
         global $wpdb;
         $table_name = $wpdb->prefix . 'paybutton_paywall_unlocked';
 
@@ -375,6 +386,13 @@ class PayButton_Admin {
      * Output the Content page.
      */
     public function content_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( isset( $_GET['paybutton_content_nonce'] ) &&
+             ! wp_verify_nonce( $_GET['paybutton_content_nonce'], 'paybutton_content_sort' ) ) {
+            wp_die( 'Security check failed' );
+        }
         global $wpdb;
         $table_name = $wpdb->prefix . 'paybutton_paywall_unlocked';
 

--- a/includes/class-paybutton-ajax.php
+++ b/includes/class-paybutton-ajax.php
@@ -46,6 +46,11 @@ class PayButton_AJAX {
      * It validates the request using a cryptographic signature to ensure authenticity.
     */
     public function payment_trigger() {
+        /*  Note to reviewers:
+        *  This endpoint is called by PayButton.org’s server, not a browser.
+        *  A wp_nonce cannot be used here (no WP session).
+        *  We instead verify a cryptographic Ed25519 signature, which guarantees authenticity.
+        */
         // Read the raw request body
         $raw_post_data = file_get_contents('php://input');
 

--- a/includes/class-paybutton-ajax.php
+++ b/includes/class-paybutton-ajax.php
@@ -47,7 +47,7 @@ class PayButton_AJAX {
     */
     public function payment_trigger() {
         /*  Note to reviewers:
-        *  This endpoint is called by PayButton.org’s server, not a browser.
+        *  This endpoint is called by PayButton.org’s server.
         *  A wp_nonce cannot be used here (no WP session).
         *  We instead verify a cryptographic Ed25519 signature, which guarantees authenticity.
         */

--- a/templates/admin/content.php
+++ b/templates/admin/content.php
@@ -23,6 +23,7 @@
             }
         }
         $url = add_query_arg( array( 'orderby' => $col, 'order' => $next_order ), $base_url );
+        $url = wp_nonce_url( $url, 'paybutton_content_sort', 'paybutton_content_nonce' );
         return '<a href="' . esc_url( $url ) . '">' . esc_html( $label . $arrow ) . '</a>';
     }
     ?>

--- a/templates/admin/customers.php
+++ b/templates/admin/customers.php
@@ -62,7 +62,7 @@
         <?php else: ?>
             <p>No unlocked content found.</p>
         <?php endif; ?>
-        <p><a href="<?php echo esc_url( admin_url( 'admin.php?page=paybutton-paywall-customers' ) ); ?>">← Back to Customers</a></p>
+        <p><a href="<?php echo esc_url(wp_nonce_url( admin_url( 'admin.php?page=paybutton-paywall-customers' ), 'paybutton_customers_sort', 'paybutton_customers_nonce' ) ); ?>">← Back to Customers</a></p>
     <?php else: ?>
         <div class="pb-header">
             <img class="paybutton-logo" src="<?php echo esc_url( PAYBUTTON_PLUGIN_URL . 'assets/paybutton-logo.png' ); ?>" alt="PayButton Logo">
@@ -83,6 +83,7 @@
                 }
             }
             $url = add_query_arg( array( 'orderby' => $col, 'order' => $next_order ), $base_url );
+            $url = wp_nonce_url( $url, 'paybutton_customers_sort', 'paybutton_customers_nonce' );
             return '<a href="' . esc_url( $url ) . '">' . esc_html( $label . $arrow ) . '</a>';
         }
         ?>

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -12,6 +12,7 @@
         <div class="updated"><p>Settings saved.</p></div>
     <?php endif; ?>
     <form method="post">
+        <?php wp_nonce_field( 'paybutton_paywall_settings', 'paybutton_settings_nonce' ); ?>
         <table class="form-table">
             <tr>
                 <th scope="row"><label for="pb_paywall_admin_wallet_address">Wallet Address (required)</label></th>


### PR DESCRIPTION
This PR fixes #49 by adding nonces and user permission check to the functions specified by the WP reviewer, except the Payment_Trigger() function, as other servers use that endpoint and is already secure because we use Ed25519 signature verification. For the later part, I left a comment in the code so that reviewers would be aware. We need to clarify it in the email too.

**Test plan:**
- Check the code
- Install the updated plugin
- Clear cache, and make sure that Paywall Settings, Customers, and Content page works as intended