### PR TITLE
Added paybutton prefix to generic option names

### DIFF
--- a/assets/js/addressValidator.bundle.js
+++ b/assets/js/addressValidator.bundle.js
@@ -753,7 +753,7 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       // Find the wallet address input field by its ID.
-      const addressInput = document.getElementById('pb_paywall_admin_wallet_address');
+      const addressInput = document.getElementById('paybutton_admin_wallet_address');
       if (!addressInput) return;
       
       // Find or create a span for validation feedback.

--- a/includes/class-paybutton-activator.php
+++ b/includes/class-paybutton-activator.php
@@ -23,13 +23,27 @@ class PayButton_Activator {
     }
 
     private static function migrate_old_option() {
-        $old_value = get_option( 'paybutton_paywall_ecash_address', '' );
-        $new_value = get_option( 'pb_paywall_admin_wallet_address', '' );
-    
-        // If old_value is present and new_value is empty, copy old to new and remove old.
-        if ( ! empty( $old_value ) && empty( $new_value ) ) {
-            update_option( 'pb_paywall_admin_wallet_address', $old_value );
-            delete_option( 'paybutton_paywall_ecash_address' );
+        // --- 1. admin wallet address ---
+        $old_admin_addr = get_option( 'pb_paywall_admin_wallet_address', '' );
+        $new_admin_addr = get_option( 'paybutton_admin_wallet_address', '' );
+        if ( ! empty( $old_admin_addr ) && empty( $new_admin_addr ) ) {
+            update_option( 'paybutton_admin_wallet_address', $old_admin_addr );
+            delete_option( 'pb_paywall_admin_wallet_address' );
+        }
+
+        // --- 2. unlocked‑indicator colours ---
+        $bg_old = get_option( 'unlocked_indicator_bg_color', '' );
+        $bg_new = get_option( 'paybutton_unlocked_indicator_bg_color', '' );
+        if ( ! empty( $bg_old ) && empty( $bg_new ) ) {
+            update_option( 'paybutton_unlocked_indicator_bg_color', $bg_old );
+            delete_option( 'unlocked_indicator_bg_color' );
+        }
+
+        $txt_old = get_option( 'unlocked_indicator_text_color', '' );
+        $txt_new = get_option( 'paybutton_unlocked_indicator_text_color', '' );
+        if ( ! empty( $txt_old ) && empty( $txt_new ) ) {
+            update_option( 'paybutton_unlocked_indicator_text_color', $txt_old );
+            delete_option( 'unlocked_indicator_text_color' );
         }
     }
 

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -78,7 +78,7 @@ class PayButton_Admin {
             current_user_can( 'manage_options' )
         ) {
             $this->save_settings();
-            wp_cache_delete( 'pb_paywall_admin_wallet_address', 'options' );
+            wp_cache_delete( 'paybutton_admin_wallet_address', 'options' );
             wp_redirect( admin_url( 'admin.php?page=paybutton-paywall&settings-updated=true' ) );
             exit;
         }
@@ -198,7 +198,7 @@ class PayButton_Admin {
 
         $args = array(
             'settings_saved'          => $settings_saved,
-            'admin_wallet_address'    => get_option( 'pb_paywall_admin_wallet_address', '' ),
+            'admin_wallet_address'    => get_option( 'paybutton_admin_wallet_address', '' ),
             'default_price'           => get_option( 'paybutton_paywall_default_price', 5.5 ),
             'current_unit'            => get_option( 'paybutton_paywall_unit', 'XEC' ),
             'btn_text'                => get_option( 'paybutton_text', 'Pay to Unlock' ),
@@ -230,7 +230,7 @@ class PayButton_Admin {
             return;
         }
 
-        $address = get_option('pb_paywall_admin_wallet_address', '');
+        $address = get_option('paybutton_admin_wallet_address', '');
         if (empty($address)) {
             echo '<div class="notice notice-error">';
             echo '<p><strong>NOTICE:</strong> Please set your wallet address in <a href="' . esc_url(admin_url('admin.php?page=paybutton-paywall')) . '">Paywall Settings</a>. If you don\'t have an address yet, create a wallet using <a href="https://cashtab.com" target="_blank">Cashtab</a>, <a href="https://www.bitcoinabc.org/electrum/" target="_blank">Electrum ABC</a> or <a href="https://electroncash.org/" target="_blank">Electron Cash</a>.</p>';
@@ -242,7 +242,7 @@ class PayButton_Admin {
      * Save settings submitted via the Paywall Settings page.
      */
     private function save_settings() {
-        $address         = sanitize_text_field( $_POST['pb_paywall_admin_wallet_address'] );
+        $address         = sanitize_text_field( $_POST['paybutton_admin_wallet_address'] );
         $unit            = sanitize_text_field( $_POST['unit'] );
         $raw_price       = floatval( $_POST['default_price'] );
         $button_text     = sanitize_text_field( $_POST['paybutton_text'] );
@@ -251,14 +251,14 @@ class PayButton_Admin {
         $color_secondary = sanitize_hex_color( $_POST['paybutton_color_secondary'] );
         $color_tertiary  = sanitize_hex_color( $_POST['paybutton_color_tertiary'] );
         $hide_comments   = isset( $_POST['paybutton_hide_comments_until_unlocked'] ) ? '1' : '0';
-        $unlocked_indicator_bg_color   = sanitize_hex_color( $_POST['unlocked_indicator_bg_color'] );
-        $unlocked_indicator_text_color = sanitize_hex_color( $_POST['unlocked_indicator_text_color'] );
+        $paybutton_unlocked_indicator_bg_color   = sanitize_hex_color( $_POST['paybutton_unlocked_indicator_bg_color'] );
+        $paybutton_unlocked_indicator_text_color = sanitize_hex_color( $_POST['paybutton_unlocked_indicator_text_color'] );
 
         if ( $unit === 'XEC' && $raw_price < 5.5 ) {
             $raw_price = 5.5;
         }
 
-        update_option( 'pb_paywall_admin_wallet_address', $address );
+        update_option( 'paybutton_admin_wallet_address', $address );
         update_option( 'paybutton_paywall_unit', $unit );
         update_option( 'paybutton_paywall_default_price', $raw_price );
         update_option( 'paybutton_text', $button_text );
@@ -278,8 +278,8 @@ class PayButton_Admin {
         // New unlocked content indicator option:
         update_option( 'paybutton_scroll_to_unlocked', isset( $_POST['paybutton_scroll_to_unlocked'] ) ? '1' : '0' );
         // Default to #007bff for background, #ffffff for text
-        update_option('unlocked_indicator_bg_color', $unlocked_indicator_bg_color ?: '#007bff');
-        update_option('unlocked_indicator_text_color', $unlocked_indicator_text_color ?: '#ffffff');
+        update_option('paybutton_unlocked_indicator_bg_color', $paybutton_unlocked_indicator_bg_color ?: '#007bff');
+        update_option('paybutton_unlocked_indicator_text_color', $paybutton_unlocked_indicator_text_color ?: '#ffffff');
 
         // Save the blacklist
         if ( isset( $_POST['paybutton_blacklist'] ) ) {

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -43,8 +43,8 @@ class PayButton_Public {
         wp_enqueue_style( 'paywall-styles', PAYBUTTON_PLUGIN_URL . 'assets/css/paywall-styles.css', array(), '1.0' );
 
         // Read the admin-chosen colors for the unlocked content indicator from options
-        $indicator_bg_color   = get_option('unlocked_indicator_bg_color', '#007bff');
-        $indicator_text_color = get_option('unlocked_indicator_text_color', '#ffffff');
+        $indicator_bg_color   = get_option('paybutton_unlocked_indicator_bg_color', '#007bff');
+        $indicator_text_color = get_option('paybutton_unlocked_indicator_text_color', '#ffffff');
 
         // Add inline CSS variables.
         $custom_css = "
@@ -113,7 +113,7 @@ class PayButton_Public {
             'nonce'          => wp_create_nonce( 'paybutton_paywall_nonce' ),
             'isUserLoggedIn' => ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? 1 : 0,
             'userAddress'    => ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? sanitize_text_field( $_SESSION['pb_paywall_user_wallet_address'] ) : '',
-            'defaultAddress' => get_option( 'pb_paywall_admin_wallet_address', '' ),
+            'defaultAddress' => get_option( 'paybutton_admin_wallet_address', '' ),
             'scrollToUnlocked' => get_option( 'paybutton_scroll_to_unlocked', '1' ),
         ) );
     }
@@ -189,7 +189,7 @@ class PayButton_Public {
 
         $atts = shortcode_atts( array(
             'price'       => $default_price,
-            'address'     => get_option( 'pb_paywall_admin_wallet_address', '' ),
+            'address'     => get_option( 'paybutton_admin_wallet_address', '' ),
             'unit'        => $default_unit,
             'button_text' => $default_text,
             'hover_text'  => $default_hover,

--- a/templates/admin/paybutton-generator.php
+++ b/templates/admin/paybutton-generator.php
@@ -3,7 +3,7 @@
     if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
     
     //Get admin's wallet address from paywall settings
-    $admin_address = get_option( 'pb_paywall_admin_wallet_address', '' );
+    $admin_address = get_option( 'paybutton_admin_wallet_address', '' );
 ?>
 
 <div class="wrap">

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -15,10 +15,10 @@
         <?php wp_nonce_field( 'paybutton_paywall_settings', 'paybutton_settings_nonce' ); ?>
         <table class="form-table">
             <tr>
-                <th scope="row"><label for="pb_paywall_admin_wallet_address">Wallet Address (required)</label></th>
+                <th scope="row"><label for="paybutton_admin_wallet_address">Wallet Address (required)</label></th>
                 <td>
                     <!-- Using the new $admin_wallet_address variable -->
-                    <input type="text" name="pb_paywall_admin_wallet_address" id="pb_paywall_admin_wallet_address" class="regular-text" value="<?php echo esc_attr( $admin_wallet_address ); ?>" required>
+                    <input type="text" name="paybutton_admin_wallet_address" id="paybutton_admin_wallet_address" class="regular-text" value="<?php echo esc_attr( $admin_wallet_address ); ?>" required>
                     <!-- This span will be populated by our bundled address validator JS -->
                     <span id="adminAddressValidationResult"></span>
                     <p class="description">Enter your wallet address to receive paywall payments.</p>
@@ -82,13 +82,13 @@
             <tbody id="unlockedIndicatorColors">
                 <tr>
                     <th scope="row">
-                        <label for="unlocked_indicator_bg_color">Background Color</label>
+                        <label for="paybutton_unlocked_indicator_bg_color">Background Color</label>
                     </th>
                     <td>
-                        <input type="color" name="unlocked_indicator_bg_color" id="unlocked_indicator_bg_color"
-                            value="<?php echo esc_attr( get_option('unlocked_indicator_bg_color', '#007bff') ); ?>">
+                        <input type="color" name="paybutton_unlocked_indicator_bg_color" id="paybutton_unlocked_indicator_bg_color"
+                            value="<?php echo esc_attr( get_option('paybutton_unlocked_indicator_bg_color', '#007bff') ); ?>">
                         <button type="button"
-                            onclick="document.getElementById('unlocked_indicator_bg_color').value = '#007bff';">
+                            onclick="document.getElementById('paybutton_unlocked_indicator_bg_color').value = '#007bff';">
                             Reset
                         </button>
                         <p class="description">Controls the background color of the indicator.</p>
@@ -96,13 +96,13 @@
                 </tr>
                 <tr>
                     <th scope="row">
-                        <label for="unlocked_indicator_text_color">Text Color</label>
+                        <label for="paybutton_unlocked_indicator_text_color">Text Color</label>
                     </th>
                     <td>
-                        <input type="color" name="unlocked_indicator_text_color" id="unlocked_indicator_text_color"
-                            value="<?php echo esc_attr( get_option('unlocked_indicator_text_color', '#ffffff') ); ?>">
+                        <input type="color" name="paybutton_unlocked_indicator_text_color" id="paybutton_unlocked_indicator_text_color"
+                            value="<?php echo esc_attr( get_option('paybutton_unlocked_indicator_text_color', '#ffffff') ); ?>">
                         <button type="button"
-                            onclick="document.getElementById('unlocked_indicator_text_color').value = '#ffffff';">
+                            onclick="document.getElementById('paybutton_unlocked_indicator_text_color').value = '#ffffff';">
                             Reset
                         </button>
                         <p class="description">Controls the text color of the indicator.</p>

--- a/templates/public/sticky-header.php
+++ b/templates/public/sticky-header.php
@@ -3,7 +3,7 @@
     if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
     // Check if the admin has set a wallet address
-    $admin_wallet_address = get_option('pb_paywall_admin_wallet_address', '');
+    $admin_wallet_address = get_option('paybutton_admin_wallet_address', '');
     if ( empty( $admin_wallet_address ) ) {
         // If no valid address is set, do not display the sticky header.
         return;


### PR DESCRIPTION
This PR fixes #54 by renaming exisitng option names to include the paybutton_ prefix. Every stored option now begins with the unique paybutton_ prefix and old installs are migrated silently (back‑compatible). 

**Test plan:**
- Remove/deactivate the plugin
- Install the updated plugin
- Go to Paywall Settings
- Make sure that the Admin wallet address and Background Color and Text Color for the 'Unlocked Content Indicator' (ofc if you have it enabled) are migrated.