### PR TITLE
Refactored Session usage with cookies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: xecdev, klakurka
 Donate link: https://donate.paybutton.org/
 Tags: paywall, monetization, donation, crypto, ecash
 Requires at least: 5.0
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.0
 Stable tag: 3.0.0
 PayButton Client: 4.1.0

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -111,8 +111,8 @@ class PayButton_Public {
         wp_localize_script( 'paybutton-cashtab-login', 'PaywallAjax', array(
             'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
             'nonce'          => wp_create_nonce( 'paybutton_paywall_nonce' ),
-            'isUserLoggedIn' => ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? 1 : 0,
-            'userAddress'    => ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? sanitize_text_field( $_SESSION['pb_paywall_user_wallet_address'] ) : '',
+            'isUserLoggedIn' => PayButton_State::get_address() ? 1 : 0,
+            'userAddress' => sanitize_text_field( PayButton_State::get_address() ),
             'defaultAddress' => get_option( 'paybutton_admin_wallet_address', '' ),
             'scrollToUnlocked' => get_option( 'paybutton_scroll_to_unlocked', '1' ),
         ) );
@@ -154,7 +154,7 @@ class PayButton_Public {
      * Output the sticky header HTML.
      */
     public function output_sticky_header() {
-        $user_wallet_address = ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? sanitize_text_field( $_SESSION['pb_paywall_user_wallet_address'] ) : '';
+        $user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
         $this->load_public_template( 'sticky-header', array(
             'user_wallet_address' => $user_wallet_address
         ) );
@@ -237,7 +237,7 @@ class PayButton_Public {
      * @return string
      */
     public function profile_shortcode() {
-        $user_wallet_address = ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ? sanitize_text_field( $_SESSION['pb_paywall_user_wallet_address'] ) : '';
+        $user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
         if ( empty( $user_wallet_address ) ) {
             return '<p>You must be logged in to view your unlocked content.</p>';
         }
@@ -259,14 +259,11 @@ class PayButton_Public {
      * Checks if the given post is unlocked for the current user.
      */
     private function post_is_unlocked( $post_id ) {
-        if ( ! session_id() ) {
-            session_start();
-        }
-        if ( ! empty( $_SESSION['paid_articles'][ $post_id ] ) && $_SESSION['paid_articles'][ $post_id ] === true ) {
+        if ( isset( PayButton_State::get_articles()[ $post_id ] ) ) {
             return true;
         }
-        if ( ! empty( $_SESSION['pb_paywall_user_wallet_address'] ) ) {
-            $address = sanitize_text_field( $_SESSION['pb_paywall_user_wallet_address'] );
+        $addr = PayButton_State::get_address(); if ( $addr ) { 
+            $address = sanitize_text_field( $addr );
             if ( $this->is_unlocked_in_db( $address, $post_id ) ) {
                 return true;
             }

--- a/includes/class-paybutton-state.php
+++ b/includes/class-paybutton-state.php
@@ -1,0 +1,237 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+final class PayButton_State {
+
+    /**
+     * cookie names & session-only cookies 
+    */
+    const COOKIE_USER_ADDR = 'paybutton_user_wallet_address';
+    const COOKIE_CONTENT  = 'paybutton_paid_content';
+    const TTL         = 604800; // one week
+
+    /**
+     * Generate HMAC of a value using WP auth salt.
+     * The function computes a SHA-256 hash of the value $message combined with 
+     * a secret key (wp_salt('auth')).
+    */
+    private static function hmac( $message ) {
+        return hash_hmac( 'sha256', $message, wp_salt( 'auth' ) );
+    }
+
+    /**
+     * Build a fingerprint string from client headers
+    */
+    private static function fingerprint() {
+        $ua   = $_SERVER['HTTP_USER_AGENT']      ?? '';
+        $ip   = $_SERVER['REMOTE_ADDR']          ?? '';
+        $lang = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
+        return "{$ua}|{$ip}|{$lang}";
+    }
+
+    /**
+     * Compose the cookie payload|fpHash|mac
+    */
+    private static function make_cookie_value( $payload ) {
+        $fpHash = self::hmac( self::fingerprint() );
+        $mac    = self::hmac( "{$payload}|{$fpHash}" );
+        return "{$payload}|{$fpHash}|{$mac}";
+    }
+
+    /**
+     * Verify the cookie structure, HMAC, and fingerprint
+    */
+    private static function verify_and_extract( $cookie, &$out_payload ) {
+        //Split the stored cookie into three parts
+        list( $payload, $fpHash, $mac ) = explode( '|', $cookie, 3 ) + [ '', '', '' ];
+        // 1) verify HMAC
+        if ( ! hash_equals( self::hmac( "{$payload}|{$fpHash}" ), $mac ) ) {
+            return false;
+        }
+        // 2) verify fingerprint
+        if ( ! hash_equals( self::hmac( self::fingerprint() ), $fpHash ) ) {
+            return false;
+        }
+        $out_payload = $payload;
+        return true;
+    }
+
+    /**
+     * Store the user wallet address in a cookie tied to fingerprint
+    */
+    public static function set_address( $addr ) {
+        $addr = sanitize_text_field( (string) $addr );
+        $cookieValue = self::make_cookie_value( $addr );
+
+        if (isset($_COOKIE[self::COOKIE_USER_ADDR]) &&
+            hash_equals($_COOKIE[self::COOKIE_USER_ADDR], $cookieValue)) {
+            return;   // nothing new → don’t send a Set-Cookie header, good for caching
+        }
+
+        if ( PHP_VERSION_ID >= 70300 ) {
+            setcookie(
+                self::COOKIE_USER_ADDR,
+                $cookieValue,
+                [
+                    'expires'  => time() + self::TTL,
+                    'path'     => '/',
+                    'domain'   => COOKIE_DOMAIN ?: '',
+                    'secure'   => is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
+            );
+        } else {
+            //Fall back to a raw header with SameSite=Lax for older PHP versions
+            $expiry = gmdate( 'D, d-M-Y H:i:s T', time() + self::TTL );
+            $header = sprintf(
+                '%s=%s; Expires=%s; Path=%s; Domain=%s; %s; HttpOnly; SameSite=Lax',
+                self::COOKIE_USER_ADDR,
+                $cookieValue,
+                $expiry,
+                '/',
+                COOKIE_DOMAIN ?: '',
+                is_ssl() ? 'Secure' : ''
+            );
+            header( 'Set-Cookie: ' . $header, false );
+        }
+        $_COOKIE[ self::COOKIE_USER_ADDR ] = $cookieValue;
+    }
+
+    /**
+     * Retrieve and validate the wallet address from cookie
+    */
+    public static function get_address() {
+        if ( empty( $_COOKIE[ self::COOKIE_USER_ADDR ] ) ) {
+            return '';
+        }
+        if ( ! self::verify_and_extract( $_COOKIE[ self::COOKIE_USER_ADDR ], $addr ) ) {
+            return '';
+        }
+        return $addr;
+    }
+
+    /**
+     * Clear the wallet address cookie
+    */
+    public static function clear_address() {
+        if ( PHP_VERSION_ID >= 70300 ) {
+            setcookie(
+                self::COOKIE_USER_ADDR,
+                '',
+                [
+                    'expires'  => time() - 3600,
+                    'path'     => '/',
+                    'domain'   => COOKIE_DOMAIN ?: '',
+                    'secure'   => is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
+            );
+        } else {
+            //Fall back to a raw header with SameSite=Lax for older PHP versions
+            $header = sprintf(
+                '%s=; Expires=%s; Path=%s; Domain=%s; %s; HttpOnly; SameSite=Lax',
+                self::COOKIE_USER_ADDR,
+                gmdate( 'D, d-M-Y H:i:s T', time() - 3600 ),
+                '/',
+                COOKIE_DOMAIN ?: '',
+                is_ssl() ? 'Secure' : ''
+            );
+            header( 'Set-Cookie: ' . $header, false );
+        }
+        unset( $_COOKIE[ self::COOKIE_USER_ADDR ] );
+    }
+
+    /**
+     * Add a post ID to the unlocked content cookie
+    */
+    public static function add_article( $post_id ) {
+        $list = array_keys( self::get_articles() );
+        $list[] = (int) $post_id;
+        $json   = wp_json_encode( array_values( array_unique( $list ) ) );
+        $payload = base64_encode( $json );
+        $cookieValue = self::make_cookie_value( $payload );
+
+        if ( isset( $_COOKIE[ self::COOKIE_CONTENT ] ) &&
+            hash_equals( $_COOKIE[ self::COOKIE_CONTENT ], $cookieValue ) ) {
+            return; // nothing new → don’t send a Set-Cookie header, good for caching
+        }
+        
+        if ( PHP_VERSION_ID >= 70300 ) {
+            setcookie(
+                self::COOKIE_CONTENT,
+                $cookieValue,
+                [
+                    'expires'  => time() + self::TTL,
+                    'path'     => '/',
+                    'domain'   => COOKIE_DOMAIN ?: '',
+                    'secure'   => is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
+            );
+        } else {
+            //Fall back to a raw header with SameSite=Lax for older PHP versions
+            $expiry = gmdate( 'D, d-M-Y H:i:s T', time() + self::TTL );
+            $header = sprintf(
+                '%s=%s; Expires=%s; Path=%s; Domain=%s; %s; HttpOnly; SameSite=Lax',
+                self::COOKIE_CONTENT,
+                $cookieValue,
+                $expiry,
+                '/',
+                COOKIE_DOMAIN ?: '',
+                is_ssl() ? 'Secure' : ''
+            );
+            header( 'Set-Cookie: ' . $header, false );
+        }
+        $_COOKIE[ self::COOKIE_CONTENT ] = $cookieValue;
+    }
+
+    /**
+     * Get the list of unlocked post IDs from cookie
+    */
+    public static function get_articles() {
+        if ( empty( $_COOKIE[ self::COOKIE_CONTENT ] ) ) {
+            return [];
+        }
+        if ( ! self::verify_and_extract( $_COOKIE[ self::COOKIE_CONTENT ], $payload ) ) {
+            return [];
+        }
+        $json = base64_decode( $payload );
+        $article_ids    = json_decode( wp_unslash( $json ), true );
+        return is_array( $article_ids ) ? array_fill_keys( $article_ids, true ) : [];
+    }
+
+    /**
+     * Clear the unlocked content cookie
+    */
+    public static function clear_articles() {
+        if ( PHP_VERSION_ID >= 70300 ) {
+            setcookie(
+                self::COOKIE_CONTENT,
+                '',
+                [
+                    'expires'  => time() - 3600,
+                    'path'     => '/',
+                    'domain'   => COOKIE_DOMAIN ?: '',
+                    'secure'   => is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
+            );
+        } else {
+            //Fall back to a raw header with SameSite=Lax for older PHP versions
+            $header = sprintf(
+                '%s=; Expires=%s; Path=%s; Domain=%s; %s; HttpOnly; SameSite=Lax',
+                self::COOKIE_CONTENT,
+                gmdate( 'D, d-M-Y H:i:s T', time() - 3600 ),
+                '/',
+                COOKIE_DOMAIN ?: '',
+                is_ssl() ? 'Secure' : ''
+            );
+            header( 'Set-Cookie: ' . $header, false );
+        }
+        unset( $_COOKIE[ self::COOKIE_CONTENT ] );
+    }
+}

--- a/paybutton.php
+++ b/paybutton.php
@@ -30,6 +30,7 @@ require_once PAYBUTTON_PLUGIN_DIR . 'includes/class-paybutton-deactivator.php';
 require_once PAYBUTTON_PLUGIN_DIR . 'includes/class-paybutton-admin.php';
 require_once PAYBUTTON_PLUGIN_DIR . 'includes/class-paybutton-public.php';
 require_once PAYBUTTON_PLUGIN_DIR . 'includes/class-paybutton-ajax.php';
+require_once PAYBUTTON_PLUGIN_DIR . 'includes/class-paybutton-state.php';
 
 /**
  * Registers the plugin's activation and deactivation hooks.
@@ -45,11 +46,6 @@ register_deactivation_hook( __FILE__, array( 'PayButton_Deactivator', 'deactivat
 
 // Initialize plugin functionality.
 add_action( 'plugins_loaded', function() {
-    // Start a PHP session if none exists.
-    if ( ! session_id() ) {
-        session_start();
-    }
-
     // Initialize admin functionality if in admin area.
     if ( is_admin() ) {
         new PayButton_Admin();


### PR DESCRIPTION
This PR fixes #52 by refactoring the code to use cookies instead of sessions. We replaced all `session_start()`-based state tracking with signed, HTTP-only cookies. Sessions turned every request into a “do-not-cache” hit, which broke performance on hosts that sit behind full-page caches (NGINX, Varnish, CDNs) and triggered a warning from the WP Plugin Review Team. Moving to cookies restores full cacheability while keeping user data on the client, and the scheme remains secure because each cookie value is protected with an HMAC derived from `wp_salt('auth')` and bound to a lightweight device fingerprint.

The new `PayButton_State` helper now stores the user’s wallet address and unlocked-content list in two cookies that expire after seven days. Cookies are set only when their value changes (reducing cache-bypass headers), are flagged `Secure`, `HttpOnly`, and `SameSite=Lax`, and are validated on every read. All previous `$_SESSION` references and session headers were removed, so sites gain immediate compatibility with managed-WordPress caching layers without altering existing paywall functionality.

**Test plan:**

- Remove the old version of the plugin
- Install and activate this new version of the plugin (make sure your test site has SSL)
- Test paywall and logging via Cashtab functionality thoroughly and make sure it works as intended