### PR TITLE
Fix nonce logic in Customers and Content pages

### DIFF
--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -304,7 +304,7 @@ class PayButton_Admin {
         // Only require nonce when sorting is requested
         if ( isset( $_GET['orderby'] ) ) {
             if ( ! isset( $_GET['paybutton_customers_nonce'] )
-            || ! wp_verify_nonce( wp_unslash( $_GET['paybutton_customers_nonce'] ), 'paybutton_customers_sort' )
+            || ! wp_verify_nonce( sanitize_text_field(wp_unslash( $_GET['paybutton_customers_nonce'] )), 'paybutton_customers_sort' )
             ) {
                 wp_die( 'Security check failed' );
             }
@@ -396,7 +396,7 @@ class PayButton_Admin {
         // Only require nonce when sorting is requested
         if ( isset( $_GET['orderby'] ) ) {
             if ( ! isset( $_GET['paybutton_content_nonce'] )
-            || ! wp_verify_nonce( wp_unslash( $_GET['paybutton_content_nonce'] ), 'paybutton_content_sort' )
+            || ! wp_verify_nonce( sanitize_text_field(wp_unslash( $_GET['paybutton_content_nonce'] )), 'paybutton_content_sort' )
             ) {
                 wp_die( 'Security check failed' );
             }

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -301,9 +301,13 @@ class PayButton_Admin {
         if ( ! current_user_can( 'manage_options' ) ) {
             return;
         }
-        if ( isset( $_GET['paybutton_customers_nonce'] ) &&
-             ! wp_verify_nonce( $_GET['paybutton_customers_nonce'], 'paybutton_customers_sort' ) ) {
-            wp_die( 'Security check failed' );
+        // Only require nonce when sorting is requested
+        if ( isset( $_GET['orderby'] ) ) {
+            if ( ! isset( $_GET['paybutton_customers_nonce'] )
+            || ! wp_verify_nonce( wp_unslash( $_GET['paybutton_customers_nonce'] ), 'paybutton_customers_sort' )
+            ) {
+                wp_die( 'Security check failed' );
+            }
         }
         global $wpdb;
         $table_name = $wpdb->prefix . 'paybutton_paywall_unlocked';
@@ -389,9 +393,13 @@ class PayButton_Admin {
         if ( ! current_user_can( 'manage_options' ) ) {
             return;
         }
-        if ( isset( $_GET['paybutton_content_nonce'] ) &&
-             ! wp_verify_nonce( $_GET['paybutton_content_nonce'], 'paybutton_content_sort' ) ) {
-            wp_die( 'Security check failed' );
+        // Only require nonce when sorting is requested
+        if ( isset( $_GET['orderby'] ) ) {
+            if ( ! isset( $_GET['paybutton_content_nonce'] )
+            || ! wp_verify_nonce( wp_unslash( $_GET['paybutton_content_nonce'] ), 'paybutton_content_sort' )
+            ) {
+                wp_die( 'Security check failed' );
+            }
         }
         global $wpdb;
         $table_name = $wpdb->prefix . 'paybutton_paywall_unlocked';


### PR DESCRIPTION
This PR fixes #63 by correcting the nonce logic for Customers and Content pages table sorting. 

**Test plan:**

- Install and activate the updated plugin
- Go to Customers and Content pages → pages should render normally (no nonce check)
- Now in either Customers page or the Content page, sort the table by clicking a column from the table
- Once the page refereshes, the URL will now include the nonce, temper with it (or remove it from the URL) and you will see → “Security check failed”.
- As a non-admin, visit those admin pages using URL (with or without params) → no access.