### PR TITLE
New style for the unlocked content indicator and obsolete migration code cleanup

### DIFF
--- a/assets/css/paywall-styles.css
+++ b/assets/css/paywall-styles.css
@@ -1,19 +1,21 @@
 .unlocked-indicator {
-    margin: 20px 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    background-color: var(--pb-unlocked-bg, #007bff);
-    color: var(--pb-unlocked-text, #ffffff);
-    padding: 8px;
-    font-family: sans-serif;
-    font-weight: bold;
-    font-size: 1.2em;
-    border-radius: 5px;
-    box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  margin: 2rem 0;
+  color: var(--pb-unlocked-indicator-color);      /* Line + text color */
+  font-family: inherit;
+  font-weight: 800;                /* Strong text */
+  font-size: 1rem;
 }
 
-.unlocked-indicator p {
-    margin: 0;
+.unlocked-indicator::before,
+.unlocked-indicator::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: currentColor;                  /* Uses the same color as the text */
+}
+
+.unlocked-indicator span {
+  padding: 0 1rem;                           /* Space between text and lines */
 }

--- a/includes/class-paybutton-activator.php
+++ b/includes/class-paybutton-activator.php
@@ -23,27 +23,12 @@ class PayButton_Activator {
     }
 
     private static function migrate_old_option() {
-        // --- 1. admin wallet address ---
-        $old_admin_addr = get_option( 'pb_paywall_admin_wallet_address', '' );
-        $new_admin_addr = get_option( 'paybutton_admin_wallet_address', '' );
-        if ( ! empty( $old_admin_addr ) && empty( $new_admin_addr ) ) {
-            update_option( 'paybutton_admin_wallet_address', $old_admin_addr );
-            delete_option( 'pb_paywall_admin_wallet_address' );
-        }
-
-        // --- 2. unlocked‑indicator colours ---
-        $bg_old = get_option( 'unlocked_indicator_bg_color', '' );
-        $bg_new = get_option( 'paybutton_unlocked_indicator_bg_color', '' );
-        if ( ! empty( $bg_old ) && empty( $bg_new ) ) {
-            update_option( 'paybutton_unlocked_indicator_bg_color', $bg_old );
-            delete_option( 'unlocked_indicator_bg_color' );
-        }
-
-        $txt_old = get_option( 'unlocked_indicator_text_color', '' );
-        $txt_new = get_option( 'paybutton_unlocked_indicator_text_color', '' );
+        // --- 1. unlocked‑indicator colours ---
+        $txt_old = get_option( 'paybutton_unlocked_indicator_text_color', '' );
+        $txt_new = get_option( 'paybutton_unlocked_indicator_color', '' );
         if ( ! empty( $txt_old ) && empty( $txt_new ) ) {
-            update_option( 'paybutton_unlocked_indicator_text_color', $txt_old );
-            delete_option( 'unlocked_indicator_text_color' );
+            update_option( 'paybutton_unlocked_indicator_color', $txt_old );
+            delete_option( 'paybutton_unlocked_indicator_text_color' );
         }
     }
 
@@ -74,31 +59,6 @@ class PayButton_Activator {
         require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
         dbDelta( $sql );
 
-        // Rename old 'ecash_address' column to 'pb_paywall_user_wallet_address', if it still exists
-        $old_col_check = $wpdb->get_var(
-            "SHOW COLUMNS FROM $table_name LIKE 'ecash_address'"
-        );
-        $new_col_check = $wpdb->get_var(
-            "SHOW COLUMNS FROM $table_name LIKE 'pb_paywall_user_wallet_address'"
-        );
-
-        if ( $old_col_check && ! $new_col_check ) {
-            $wpdb->query("ALTER TABLE $table_name CHANGE ecash_address pb_paywall_user_wallet_address VARCHAR(255) NOT NULL");
-        }
-
-        // Rename old index 'ecash_address_idx' to 'pb_paywall_user_wallet_address_idx'
-        $old_idx_check = $wpdb->get_var("
-            SHOW INDEX FROM $table_name WHERE Key_name = 'ecash_address_idx'
-        ");
-        $new_idx_check = $wpdb->get_var("
-            SHOW INDEX FROM $table_name WHERE Key_name = 'pb_paywall_user_wallet_address_idx'
-        ");
-        if ( $old_idx_check && ! $new_idx_check ) {
-            // Drop the old index
-            $wpdb->query("ALTER TABLE $table_name DROP INDEX ecash_address_idx");
-            // Add the new one
-            $wpdb->query("ALTER TABLE $table_name ADD INDEX pb_paywall_user_wallet_address_idx (pb_paywall_user_wallet_address)");
-        }
     }
 
     /**

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -251,8 +251,7 @@ class PayButton_Admin {
         $color_secondary = sanitize_hex_color( $_POST['paybutton_color_secondary'] );
         $color_tertiary  = sanitize_hex_color( $_POST['paybutton_color_tertiary'] );
         $hide_comments   = isset( $_POST['paybutton_hide_comments_until_unlocked'] ) ? '1' : '0';
-        $paybutton_unlocked_indicator_bg_color   = sanitize_hex_color( $_POST['paybutton_unlocked_indicator_bg_color'] );
-        $paybutton_unlocked_indicator_text_color = sanitize_hex_color( $_POST['paybutton_unlocked_indicator_text_color'] );
+        $paybutton_unlocked_indicator_color = sanitize_hex_color( $_POST['paybutton_unlocked_indicator_color'] );
 
         if ( $unit === 'XEC' && $raw_price < 5.5 ) {
             $raw_price = 5.5;
@@ -277,9 +276,8 @@ class PayButton_Admin {
 
         // New unlocked content indicator option:
         update_option( 'paybutton_scroll_to_unlocked', isset( $_POST['paybutton_scroll_to_unlocked'] ) ? '1' : '0' );
-        // Default to #007bff for background, #ffffff for text
-        update_option('paybutton_unlocked_indicator_bg_color', $paybutton_unlocked_indicator_bg_color ?: '#007bff');
-        update_option('paybutton_unlocked_indicator_text_color', $paybutton_unlocked_indicator_text_color ?: '#ffffff');
+        // Default to  #000000 for text
+        update_option('paybutton_unlocked_indicator_color', $paybutton_unlocked_indicator_color ?: '#000000');
 
         // Save the blacklist
         if ( isset( $_POST['paybutton_blacklist'] ) ) {

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -42,9 +42,8 @@ class PayButton_Public {
         // Enqueue our new paywall styles
         wp_enqueue_style( 'paywall-styles', PAYBUTTON_PLUGIN_URL . 'assets/css/paywall-styles.css', array(), '1.0' );
 
-        // Read the admin-chosen colors for the unlocked content indicator from options
-        $indicator_bg_color   = get_option('paybutton_unlocked_indicator_bg_color', '#007bff');
-        $indicator_text_color = get_option('paybutton_unlocked_indicator_text_color', '#ffffff');
+        // Read the admin-chosen color for the unlocked content indicator from options
+        $pb_indicator_color = get_option('paybutton_unlocked_indicator_color', '#000000');
 
         // Add inline CSS variables.
         $custom_css = "
@@ -55,8 +54,7 @@ class PayButton_Public {
                 --profile-button-text-color: " . esc_attr( get_option('paybutton_profile_button_text_color', '#000') ) . ";
                 --logout-button-bg-color: " . esc_attr( get_option('paybutton_logout_button_bg_color', '#d9534f') ) . ";
                 --logout-button-text-color: " . esc_attr( get_option('paybutton_logout_button_text_color', '#fff') ) . ";
-                --pb-unlocked-bg: {$indicator_bg_color};
-                --pb-unlocked-text: {$indicator_text_color};
+                --pb-unlocked-indicator-color: {$pb_indicator_color};
             }
         ";
         wp_add_inline_style( 'paybutton-sticky-header', esc_attr( $custom_css ) );
@@ -201,7 +199,7 @@ class PayButton_Public {
             $indicator = '';
             if ( get_option('paybutton_scroll_to_unlocked', '0') === '1' ) {
                 $indicator = '<div id="unlocked" class="unlocked-indicator">
-                                  <p>Unlocked Content Below</p>
+                                  <span>Unlocked Content Below</span>
                               </div>';
             }
             return $indicator . do_shortcode( $content );

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -82,30 +82,16 @@
             <tbody id="unlockedIndicatorColors">
                 <tr>
                     <th scope="row">
-                        <label for="paybutton_unlocked_indicator_bg_color">Background Color</label>
+                        <label for="paybutton_unlocked_indicator_color">Indicator Color</label>
                     </th>
                     <td>
-                        <input type="color" name="paybutton_unlocked_indicator_bg_color" id="paybutton_unlocked_indicator_bg_color"
-                            value="<?php echo esc_attr( get_option('paybutton_unlocked_indicator_bg_color', '#007bff') ); ?>">
+                        <input type="color" name="paybutton_unlocked_indicator_color" id="paybutton_unlocked_indicator_color"
+                            value="<?php echo esc_attr( get_option('paybutton_unlocked_indicator_color', '#000000') ); ?>">
                         <button type="button"
-                            onclick="document.getElementById('paybutton_unlocked_indicator_bg_color').value = '#007bff';">
+                            onclick="document.getElementById('paybutton_unlocked_indicator_color').value = '#000000';">
                             Reset
                         </button>
-                        <p class="description">Controls the background color of the indicator.</p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row">
-                        <label for="paybutton_unlocked_indicator_text_color">Text Color</label>
-                    </th>
-                    <td>
-                        <input type="color" name="paybutton_unlocked_indicator_text_color" id="paybutton_unlocked_indicator_text_color"
-                            value="<?php echo esc_attr( get_option('paybutton_unlocked_indicator_text_color', '#ffffff') ); ?>">
-                        <button type="button"
-                            onclick="document.getElementById('paybutton_unlocked_indicator_text_color').value = '#ffffff';">
-                            Reset
-                        </button>
-                        <p class="description">Controls the text color of the indicator.</p>
+                        <p class="description">Controls the text and line colors of the unlocked content indicator.</p>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
This PR introduces a new style for the Unlocked Content Indicator and cleans up old migration code.

![image](https://github.com/user-attachments/assets/ad5e7e76-2fd8-4ba8-8a6f-dd16bca81f8b)

**Test plan:**
- Install and activate the plugin
- In Paywall Settings check the option for the Unlocked Content Indicator
- Choose your favorite color and test on the front end (make sure to clear the cache).