### PR TITLE
Show Unlock Count on Front-end

### DIFF
--- a/assets/css/paywall-styles.css
+++ b/assets/css/paywall-styles.css
@@ -19,3 +19,13 @@
 .unlocked-indicator span {
   padding: 0 1rem;                           /* Space between text and lines */
 }
+
+/* Show Unlock Count on Front-end */
+.pb-frontend-unlock-count {
+  color: var(--pb-frontend-unlock-color, #0074C2);
+  margin-bottom: 1em;
+  text-align: center;
+  font-family: inherit;
+  font-size: 1.2em;
+  font-style: italic;
+}

--- a/assets/js/paybutton-admin.js
+++ b/assets/js/paybutton-admin.js
@@ -16,4 +16,21 @@ jQuery(document).ready(function($) {
     toggleColorFields();
     // On checkbox change
     unlockedCheckbox.on('change', toggleColorFields);
+
+    //NEW: Toggle the “Unlock Count Color” row visibility
+    var enableUnlockCountCheckbox   = $('#paybutton_enable_frontend_unlock_count');
+    var frontendUnlockColorRow      = $('#paybutton_frontend_unlock_color_row');
+
+    function toggleFrontendUnlockColorRow() {
+    if ( enableUnlockCountCheckbox.is(':checked') ) {
+        frontendUnlockColorRow.show();
+    } else {
+        frontendUnlockColorRow.hide();
+    }
+    }
+
+    // On page load
+    toggleFrontendUnlockColorRow();
+    // On checkbox change
+    enableUnlockCountCheckbox.on('change', toggleFrontendUnlockColorRow);
 });

--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -295,7 +295,17 @@ class PayButton_Admin {
         if ( isset( $_POST['paybutton_public_key'] ) ) {
             $public_key = sanitize_text_field( $_POST['paybutton_public_key'] );
             update_option( 'paybutton_public_key', $public_key );
-        }    
+        }
+        
+        //Front‐end unlock count toggle
+        $enable_frontend_unlock_count = isset( $_POST['paybutton_enable_frontend_unlock_count'] ) ? '1' : '0';
+        update_option( 'paybutton_enable_frontend_unlock_count', $enable_frontend_unlock_count );
+
+        //Front‐end unlock count text color
+        $frontend_unlock_color = isset( $_POST['paybutton_frontend_unlock_color'] )
+            ? sanitize_hex_color( wp_unslash( $_POST['paybutton_frontend_unlock_color'] ) )
+            : '#0074C2';
+        update_option( 'paybutton_frontend_unlock_color', $frontend_unlock_color );
     }
 
     /**

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -95,6 +95,44 @@
                     </td>
                 </tr>
             </tbody>
+            <!-- Show Unlock Count on Front‐end -->
+            <tr>
+                <th scope="row">Show Unlock Count on Front‐end</th>
+                <td>
+                    <label>
+                        <input 
+                            type="checkbox" 
+                            name="paybutton_enable_frontend_unlock_count" 
+                            id="paybutton_enable_frontend_unlock_count"
+                            value="1"
+                            <?php checked( get_option( 'paybutton_enable_frontend_unlock_count', '0' ), '1' ); ?>
+                        >
+                        <span>Enable unlock‐count label above PayButton on public posts</span>
+                    </label>
+                </td>
+            </tr>
+
+            <!-- Unlock Count Color Picker (hidden until above box is checked) -->
+            <tr id="paybutton_frontend_unlock_color_row">
+                <th scope="row">
+                    <label for="paybutton_frontend_unlock_color">Unlock Count Label Color</label>
+                </th>
+                <td>
+                    <input 
+                    type="color" 
+                    name="paybutton_frontend_unlock_color" 
+                    id="paybutton_frontend_unlock_color"
+                    value="<?php echo esc_attr( get_option( 'paybutton_frontend_unlock_color', '#0074C2' ) ); ?>"
+                    >
+                    <button type="button"
+                    onclick="document.getElementById('paybutton_frontend_unlock_color').value = '#0074C2';">
+                    Reset
+                    </button>
+                    <p class="description">
+                    Pick the hex color for the unlock count label.
+                    </p>
+                </td>
+            </tr>
             <!-- Sticky Header Settings -->
             <tr>
                 <th colspan="2"><h2>Sticky Header Settings</h2></th>


### PR DESCRIPTION
This PR implements the feature requested in #28. This feature is disabled by default and can be enabled from the Paywall Settings.

**Test plan:**
- Install and activate the plugin
- Enable the new "Show Unlock Count on Front‐end" feature from Paywall Settings
- Test it on posts