### PR TITLE
Fix logout button nonce expiry

### DIFF
--- a/assets/js/paybutton-paywall-cashtab-login.js
+++ b/assets/js/paybutton-paywall-cashtab-login.js
@@ -76,3 +76,22 @@ window.addEventListener('load', function() {
         isLoggedIn = true;
     }
 });
+
+//The following code reloads the page if the user has been idle for more than 10 minutes, to renew the logout button's nonce validity.
+// Track last time the page was active
+let lastActive = Date.now();
+
+// Update timestamp whenever the tab is focused or user interacts
+window.addEventListener('focus', () => {
+    const now = Date.now();
+    const idleMinutes = (now - lastActive) / 60000; // Convert ms to minutes
+    if (idleMinutes > 10) {
+        location.reload(); // Reload if idle for more than 10 minutes to renew the logout button nonce
+    }
+    lastActive = now;
+});
+
+// Also update the timestamp on clicks/scrolls to keep it fresh
+['click','scroll','keydown','mousemove'].forEach(evt => {
+    window.addEventListener(evt, () => { lastActive = Date.now(); });
+});


### PR DESCRIPTION
This PR fixes #86 by adding a simple client-side check that reloads the page after being out of focus (idle) for 10 minutes, ensuring a fresh nonce is generated and the logout action completes successfully without user confusion.

**Test Plan**
1. Install the plugin or use the prepared test site.
2. Log in via Cashtab to generate a valid nonce.
3. **Short Idle (<10 min)**
   - Switch to a different browser tab.
   - Return to the WordPress site within 10 minutes.
   - Page should not reload.
   - Logout button should work without errors.
4. **Long Idle (>10 min)**
   - Switch to a different tab again.
   - Remain away for longer than 10 minutes.
   - Return to the WordPress site.
   - Page should automatically reload on focus.
   - A fresh nonce should be issued.
   - Logout button should work correctly after reload.