### PR TITLE
Add contact email

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,6 +38,7 @@ Wrap your content in the `[paywalled_content]` shortcode to protect it, no codin
 * **[Documentation](https://docs.paybutton.org/)**
 * **[Support](https://t.me/paybutton)**
 * **[Website](https://paybutton.org)**
+* **[Email](mailto:contact@paybutton.org)**
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
Adds contact email to the readme.

**Test plan:**
- Validate/preview [here](https://wpreadme.com/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added an Email contact link under the Documentation & Support section, providing a direct mailto link to contact@paybutton.org placed after the Website link.
  - Improves visibility of support options and makes it easier for users to reach the team for assistance or inquiries.
  - No other content changes; structure and existing links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->