### PR TITLE
add prefix to global variables

### DIFF
--- a/includes/class-paybutton-admin.php
+++ b/includes/class-paybutton-admin.php
@@ -204,7 +204,7 @@ class PayButton_Admin {
 
         $args = array(
             'settings_saved'          => $settings_saved,
-            'admin_wallet_address'    => get_option( 'paybutton_admin_wallet_address', '' ),
+            'paybutton_admin_wallet_address'    => get_option( 'paybutton_admin_wallet_address', '' ),
             'default_price'           => get_option( 'paybutton_paywall_default_price', 5.5 ),
             'current_unit'            => get_option( 'paybutton_paywall_unit', 'XEC' ),
             'btn_text'                => get_option( 'paybutton_text', 'Pay to Unlock' ),

--- a/includes/class-paybutton-ajax.php
+++ b/includes/class-paybutton-ajax.php
@@ -397,7 +397,7 @@ class PayButton_AJAX {
         }
 
         // Run the full post-content pipeline (blocks, shortcodes, embeds, autop, etc.) filter
-        $body = apply_filters( 'the_content', $inner );
+        $body = apply_filters( 'the_content', $inner ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- core hook
 
         // Restore the flag
         if ( isset( $wp_query ) ) {

--- a/includes/class-paybutton-public.php
+++ b/includes/class-paybutton-public.php
@@ -163,9 +163,9 @@ class PayButton_Public {
      * Output the sticky header HTML.
      */
     public function output_sticky_header() {
-        $user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
+        $paybutton_user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
         $this->load_public_template( 'sticky-header', array(
-            'user_wallet_address' => $user_wallet_address
+            'paybutton_user_wallet_address' => $paybutton_user_wallet_address
         ) );
     }
 
@@ -280,20 +280,20 @@ class PayButton_Public {
      * @return string
      */
     public function profile_shortcode() {
-        $user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
-        if ( empty( $user_wallet_address ) ) {
+        $paybutton_user_wallet_address = sanitize_text_field( PayButton_State::get_address() );
+        if ( empty( $paybutton_user_wallet_address ) ) {
             return '<p>You must be logged in to view your unlocked content.</p>';
         }
         global $wpdb;
         $table_name = $wpdb->prefix . 'paybutton_paywall_unlocked';
-        $rows       = $wpdb->get_results( $wpdb->prepare(
+        $paybutton_rows       = $wpdb->get_results( $wpdb->prepare(
             "SELECT DISTINCT post_id FROM $table_name WHERE pb_paywall_user_wallet_address = %s ORDER BY id DESC",
-            $user_wallet_address
+            $paybutton_user_wallet_address
         ) );
         ob_start();
         $this->load_public_template( 'profile', array(
-            'user_wallet_address' => $user_wallet_address,
-            'rows'                => $rows
+            'paybutton_user_wallet_address' => $paybutton_user_wallet_address,
+            'paybutton_rows'                => $paybutton_rows
         ) );
         return ob_get_clean();
     }

--- a/templates/admin/content.php
+++ b/templates/admin/content.php
@@ -37,23 +37,21 @@
         </thead>
         <tbody>
             <?php if ( ! empty( $contentData ) ): ?>
-                <?php foreach ( $contentData as $row ): 
-                    $permalink = get_permalink( $row['post_id'] );
+                <?php foreach ( $contentData as $paybutton_row ): 
+                    $paybutton_permalink = get_permalink( $paybutton_row['post_id'] );
                     ?>
                     <tr>
                         <td>
-                            <a href="<?php echo esc_url( $permalink ); ?>" target="_blank">
-                                <?php echo esc_html( $row['title'] ); ?>
+                            <a href="<?php echo esc_url( $paybutton_permalink ); ?>" target="_blank">
+                                <?php echo esc_html( $paybutton_row['title'] ); ?>
                             </a>
                         </td>
                         <td>
                             <?php
-                            echo intval( $row['unlock_count'] )
-                                //  . ' (' . intval( $row['unlock_logged_in_count'] ) . ' accounts)'
-                                ;
+                            echo intval( $paybutton_row['unlock_count'] );
                             ?>
                         </td>
-                        <td><?php echo esc_html( number_format( $row['total_earned'], 2 ) ); ?></td>
+                        <td><?php echo esc_html( number_format( $paybutton_row['total_earned'], 2 ) ); ?></td>
                     </tr>
                 <?php endforeach; ?>
             <?php else: ?>

--- a/templates/admin/customers.php
+++ b/templates/admin/customers.php
@@ -21,38 +21,38 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ( $rows as $row ):
-                        $post_title = get_the_title( $row->post_id );
-                        $permalink  = get_permalink( $row->post_id );
-                        if ( $post_title && $permalink ): ?>
+                    <?php foreach ( $rows as $paybutton_row ):
+                        $paybutton_post_title = get_the_title( $paybutton_row->post_id );
+                        $paybutton_permalink  = get_permalink( $paybutton_row->post_id );
+                        if ( $paybutton_post_title && $paybutton_permalink ): ?>
                             <tr>
                                 <td>
-                                    <a href="<?php echo esc_url( $permalink ); ?>" target="_blank">
-                                        <?php echo esc_html( $post_title ); ?>
+                                    <a href="<?php echo esc_url( $paybutton_permalink ); ?>" target="_blank">
+                                        <?php echo esc_html( $paybutton_post_title ); ?>
                                     </a>
                                 </td>
-                                <td><?php echo number_format( floatval( $row->tx_amount ), 2 ); ?></td>
+                                <td><?php echo number_format( floatval( $paybutton_row->tx_amount ), 2 ); ?></td>
                                 <?php
-                                $converted_ts = '(none)';
-                                if ( ! empty( $row->tx_timestamp ) && $row->tx_timestamp !== '0000-00-00 00:00:00' ) {
-                                    $local_time = get_date_from_gmt( $row->tx_timestamp );
-                                    if ( $local_time ) {
-                                        $converted_ts = date_i18n( 'Y-m-d H:i:s', strtotime( $local_time ) );
+                                $paybutton_converted_ts = '(none)';
+                                if ( ! empty( $paybutton_row->tx_timestamp ) && $paybutton_row->tx_timestamp !== '0000-00-00 00:00:00' ) {
+                                    $paybutton_local_time = get_date_from_gmt( $paybutton_row->tx_timestamp );
+                                    if ( $paybutton_local_time ) {
+                                        $paybutton_converted_ts = date_i18n( 'Y-m-d H:i:s', strtotime( $paybutton_local_time ) );
                                     }
                                 }
                                 ?>
-                                <td><?php echo esc_html( $converted_ts ); ?></td>
-                                <?php if ( ! empty( $row->tx_hash ) ): ?>
+                                <td><?php echo esc_html( $paybutton_converted_ts ); ?></td>
+                                <?php if ( ! empty( $paybutton_row->tx_hash ) ): ?>
                                     <td>
-                                        <a href="https://explorer.e.cash/tx/<?php echo urlencode( $row->tx_hash ); ?>" target="_blank">
-                                            <?php echo esc_html( $row->tx_hash ); ?>
+                                        <a href="https://explorer.e.cash/tx/<?php echo urlencode( $paybutton_row->tx_hash ); ?>" target="_blank">
+                                            <?php echo esc_html( $paybutton_row->tx_hash ); ?>
                                         </a>
                                     </td>
                                 <?php else: ?>
                                     <td>(none)</td>
                                 <?php endif; ?>
                                 <td>
-                                    <?php echo esc_html( $row->is_logged_in ? 'true' : 'false' ); ?>
+                                    <?php echo esc_html( $paybutton_row->is_logged_in ? 'true' : 'false' ); ?>
                                 </td>
                             </tr>
                         <?php endif;
@@ -98,35 +98,35 @@
             </thead>
             <tbody>
                 <?php if ( ! empty( $customers ) ): ?>
-                    <?php foreach ( $customers as $row ): 
-                        $detail_link = add_query_arg( array(
+                    <?php foreach ( $customers as $paybutton_row ): 
+                        $paybutton_detail_link = add_query_arg( array(
                             'page'    => 'paybutton-paywall-customers',
-                            'address' => $row['pb_paywall_user_wallet_address']
+                            'address' => $paybutton_row['pb_paywall_user_wallet_address']
                         ), admin_url( 'admin.php' ) );
                         ?>
                         <tr>
                             <td>
-                                <a href="<?php echo esc_url( $detail_link ); ?>">
-                                    <?php echo esc_html( $row['pb_paywall_user_wallet_address'] ); ?>
+                                <a href="<?php echo esc_url( $paybutton_detail_link ); ?>">
+                                    <?php echo esc_html( $paybutton_row['pb_paywall_user_wallet_address'] ); ?>
                                 </a>
                             </td>
                             <td>
                                 <?php
-                                echo intval( $row['unlocked_count'] )
-                                    //  . ' (' . intval( $row['unlocked_logged_in_count'] ) . ' accounts)'
+                                echo intval( $paybutton_row['unlocked_count'] )
+                                    //  . ' (' . intval( $paybutton_row['unlocked_logged_in_count'] ) . ' accounts)'
                                     ;
                                 ?>
                             </td>
-                            <td><?php echo esc_html( number_format( $row['total_paid'], 2 ) ); ?></td>
+                            <td><?php echo esc_html( number_format( $paybutton_row['total_paid'], 2 ) ); ?></td>
                             <td>
                                 <?php
                                 // Convert MySQL datetime to something friendly
-                                if ( ! empty( $row['last_unlock_ts'] ) && $row['last_unlock_ts'] !== '0000-00-00 00:00:00' ) {
-                                    $local_time = get_date_from_gmt( $row['last_unlock_ts'] );
-                                    if ( $local_time ) {
-                                        echo esc_html( date_i18n( 'Y-m-d H:i:s', strtotime( $local_time ) ) );
+                                if ( ! empty( $paybutton_row['last_unlock_ts'] ) && $paybutton_row['last_unlock_ts'] !== '0000-00-00 00:00:00' ) {
+                                    $paybutton_local_time = get_date_from_gmt( $paybutton_row['last_unlock_ts'] );
+                                    if ( $paybutton_local_time ) {
+                                        echo esc_html( date_i18n( 'Y-m-d H:i:s', strtotime( $paybutton_local_time ) ) );
                                     } else {
-                                        echo esc_html( $row['last_unlock_ts'] ); // fallback
+                                        echo esc_html( $paybutton_row['last_unlock_ts'] ); // fallback
                                     }
                                 } else {
                                     echo '(none)';

--- a/templates/admin/paybutton-generator.php
+++ b/templates/admin/paybutton-generator.php
@@ -3,7 +3,7 @@
     if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
     
     //Get admin's wallet address from paywall settings
-    $admin_address = get_option( 'paybutton_admin_wallet_address', '' );
+    $paybutton_admin_wallet_address = get_option( 'paybutton_admin_wallet_address', '' );
 ?>
 
 <div class="wrap">
@@ -22,7 +22,7 @@
         type="text" 
         id="pbGenTo" 
         placeholder="Your Wallet Address (XEC or BCH)"
-        value="<?php echo esc_attr( $admin_address ); ?>"
+        value="<?php echo esc_attr( $paybutton_admin_wallet_address ); ?>"
         class="pb-generator-input"
       >
 

--- a/templates/admin/paywall-settings.php
+++ b/templates/admin/paywall-settings.php
@@ -17,8 +17,8 @@
             <tr>
                 <th scope="row"><label for="paybutton_admin_wallet_address">Wallet Address (required)</label></th>
                 <td>
-                    <!-- Using the new $admin_wallet_address variable -->
-                    <input type="text" name="paybutton_admin_wallet_address" id="paybutton_admin_wallet_address" class="regular-text" value="<?php echo esc_attr( $admin_wallet_address ); ?>" required>
+                    <!-- Using the new $paybutton_admin_wallet_address variable -->
+                    <input type="text" name="paybutton_admin_wallet_address" id="paybutton_admin_wallet_address" class="regular-text" value="<?php echo esc_attr( $paybutton_admin_wallet_address ); ?>" required>
                     <!-- This span will be populated by our bundled address validator JS -->
                     <span id="adminAddressValidationResult"></span>
                     <p class="description">Enter your wallet address to receive paywall payments.</p>

--- a/templates/public/profile.php
+++ b/templates/public/profile.php
@@ -6,16 +6,16 @@
 <div class="paybutton-profile">
     <p>
         <strong>Wallet Address:</strong>
-        <a href="https://explorer.e.cash/address/<?php echo esc_attr( $user_wallet_address ); ?>" target="_blank">
-            <?php echo esc_html( $user_wallet_address ); ?>
+        <a href="https://explorer.e.cash/address/<?php echo esc_attr( $paybutton_user_wallet_address ); ?>" target="_blank">
+            <?php echo esc_html( $paybutton_user_wallet_address ); ?>
         </a>
     </p>
     <h3>Unlocked Content:</h3>
-    <?php if ( ! empty( $rows ) ): ?>
+    <?php if ( ! empty( $paybutton_rows ) ): ?>
         <ol>
-            <?php foreach ( $rows as $row ):
-                $title = get_the_title( $row->post_id );
-                $link  = get_permalink( $row->post_id );
+            <?php foreach ( $paybutton_rows as $paybutton_row ):
+                $title = get_the_title( $paybutton_row->post_id );
+                $link  = get_permalink( $paybutton_row->post_id );
                 if ( $title && $link ): ?>
                     <li><a href="<?php echo esc_url( $link ); ?>"><?php echo esc_html( $title ); ?></a></li>
                 <?php endif;

--- a/templates/public/sticky-header.php
+++ b/templates/public/sticky-header.php
@@ -3,8 +3,8 @@
     if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
     // Check if the admin has set a wallet address
-    $admin_wallet_address = get_option('paybutton_admin_wallet_address', '');
-    if ( empty( $admin_wallet_address ) ) {
+    $paybutton_admin_wallet_address = get_option('paybutton_admin_wallet_address', '');
+    if ( empty( $paybutton_admin_wallet_address ) ) {
         // If no valid address is set, do not display the sticky header.
         return;
     }
@@ -39,7 +39,7 @@
 ?>
 
 <div id="cashtab-sticky-header">
-    <?php if ( ! $user_wallet_address ): ?>
+    <?php if ( ! $paybutton_user_wallet_address ): ?>
         <div id="loginPaybutton"></div>
     <?php else: ?>
         <div class="logged-in-actions">


### PR DESCRIPTION
This PR fixes #91 (WordPress.NamingConventions error) by prefixing global variables with paybutton_.

**Test plan:**
- Install the updated plugin
- Check the plugin with PCP (Plugin Check) for WordPress.NamingConventions errors.
- Verify there are no errros

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added `paybutton_` prefix to global variables across template files and classes to comply with WordPress coding standards.

- Prefixed variables passed to templates in `class-paybutton-admin.php` and `class-paybutton-public.php`
- Updated all loop variables (`$row` → `$paybutton_row`) across admin and public templates
- Renamed local variables in templates to include `paybutton_` prefix
- Added proper phpcs ignore comment for WordPress core hook `the_content`
- **Issue**: `templates/public/profile.php` has incomplete prefixing - variables `$title` and `$link` on lines 17-18 are missing the `paybutton_` prefix, inconsistent with the rest of the changes

<h3>Confidence Score: 2/5</h3>


- This PR has incomplete implementation that will cause undefined variable errors
- The changes are syntactically correct and follow WordPress coding standards, but `templates/public/profile.php` has inconsistent variable naming where `$title` and `$link` are missing the `paybutton_` prefix while being used in the template. This creates undefined variable references since the template expects `$paybutton_title` and `$paybutton_link` but these are never defined.
- `templates/public/profile.php` requires immediate attention - lines 17-20 have unprefixed variables that will cause runtime errors

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| includes/class-paybutton-public.php | 5/5 | Renamed variables to include `paybutton_` prefix for WordPress coding standards compliance |
| templates/admin/customers.php | 5/5 | Consistently prefixed all template variables with `paybutton_` throughout the file |
| templates/public/profile.php | 1/5 | Partially updated variables - missing prefix on `$title` and `$link` loop variables |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Template as Template Files
    participant Class as PHP Classes
    participant WP as WordPress Core
    
    Note over Dev,WP: Global Variable Prefixing Changes
    
    Dev->>Class: Update class-paybutton-admin.php
    Class->>Class: Rename array key to paybutton_admin_wallet_address
    
    Dev->>Class: Update class-paybutton-public.php
    Class->>Class: Rename $user_wallet_address → $paybutton_user_wallet_address
    Class->>Class: Rename $rows → $paybutton_rows
    Class->>Template: Pass prefixed variables to templates
    
    Dev->>Class: Update class-paybutton-ajax.php
    Class->>WP: Add phpcs:ignore for core hook
    Note over Class,WP: Core WordPress hook doesn't need prefix
    
    Dev->>Template: Update admin templates
    Template->>Template: Prefix all loop variables with paybutton_
    Template->>Template: Rename $row → $paybutton_row
    Template->>Template: Rename local vars (permalink, post_title, etc)
    
    Dev->>Template: Update public templates
    Template->>Template: Receive prefixed variables
    Template->>Template: Update sticky-header.php ✓
    Template->>Template: Update profile.php (incomplete)
    Note over Template: $title and $link missing prefix
    
    Note over Dev,WP: WordPress Coding Standards Compliance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->