### PR TITLE
Switch Wallet in Auto-login

### DIFF
--- a/includes/class-paybutton-ajax.php
+++ b/includes/class-paybutton-ajax.php
@@ -344,7 +344,7 @@ class PayButton_AJAX {
 
         $wallet_address = sanitize_text_field($row->pb_paywall_user_wallet_address);
         // 🔐 Auto-login from wallet address returned in the server-verified row
-        if ( ! PayButton_State::get_address() && ! empty( $wallet_address ) ) {
+        if ( ! empty( $wallet_address ) && PayButton_State::get_address() !== $wallet_address ) {
             PayButton_State::set_address( $wallet_address );
         }
 


### PR DESCRIPTION
This PR fixes #110. by updating the auto-login logic so the wallet used for an unlock replaces the currently logged-in wallet, ensuring correct switching during consecutive unlocks.

**Test Plan:**
- Install the plugin
- Unlock a content with wallet A
- Now unlock a content with wallet B
- Make sure your wallet is updated to B (you can confirm by checking the Profile page)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic login behavior for wallet address changes. Users can now successfully auto-login when switching to a different wallet address, while unnecessary re-processing of the same address is prevented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->